### PR TITLE
Fix headers to match SNIP-1

### DIFF
--- a/SNIPS/snip-1.md
+++ b/SNIPS/snip-1.md
@@ -1,9 +1,9 @@
 ---
 snip: 1
 title: SNIP Purpose and Guidelines
+author: Martín Triay <martriay@gmail.com>
 status: Living
 type: Meta
-author: Martín Triay <martriay@gmail.com>
 created: 2022-06-03
 ---
 

--- a/SNIPS/snip-2.md
+++ b/SNIPS/snip-2.md
@@ -1,9 +1,10 @@
 ---
 snip: 2
 title: Token Standard
-status: Draft
-type: SRC
 author: Abdelhamid Bakhta <abdelhamid.bakhta@gmail.com>
+status: Draft
+type: Standards Track
+category: SRC
 created: 2022-06-03
 ---
 

--- a/SNIPS/snip-3.md
+++ b/SNIPS/snip-3.md
@@ -1,9 +1,10 @@
 ---
 snip: 3
 title: Non-Fungible Token Standard
-status: Draft
-type: SRC
 author: Abdelhamid Bakhta <abdelhamid.bakhta@gmail.com>
+status: Draft
+type: Standards Track
+category: SRC
 created: 2022-06-03
 ---
 

--- a/SNIPS/snip-4.md
+++ b/SNIPS/snip-4.md
@@ -1,9 +1,9 @@
 ---
 snip: 4
 title: Cairo Comment Standard
+author: Orlando Fraser <orlandothefraser@gmail.com>
 status: Draft
 type: Informational
-author: Orlando Fraser <orlandothefraser@gmail.com>
 created: 2022-06-13
 ---
 


### PR DESCRIPTION
Fixes order of the headers, and type entry usage:

For Standard Track SNIPs, the `type` header entry shouldn't be `SRC`, but `Standard Track`, and `SRC` should be the `category` as specified [here](https://github.com/ericnordelo/SNIPs/blob/c17bbb47337a1a82765b81775621721c71e2f546/SNIPS/snip-1.md?plain=1#L128).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-io/SNIPs/22)
<!-- Reviewable:end -->
