### PR TITLE
Fix errors in documentation files

### DIFF
--- a/SNIPS/snip-13.md
+++ b/SNIPS/snip-13.md
@@ -15,17 +15,17 @@ In this SNIP we suggest updating StarkGate's ERC20s (including ETH, STRK, USDC [
 
 ## Motivation
 
-Dapps, for example exchanges that operate on Starknet, need to track transfers from & to specific addresses. At the moment, Starknet's json-rpc only allows receiving all `Transfer` or `Approval` events from a given ERC20 in a particular block range. This SNIP would enable filtering those events, allowing filteration by `from` or `to` in `Transfer` events and by `owner` or `spender` in `Approval` events.
+Dapps, for example exchanges that operate on Starknet, need to track transfers from & to specific addresses. At the moment, Starknet's json-rpc only allows receiving all `Transfer` or `Approval` events from a given ERC20 in a particular block range. This SNIP would enable filtering those events, allowing filtering by `from` or `to` in `Transfer` events and by `owner` or `spender` in `Approval` events.
 
 This is already the case on Ethereum and other EVM chains. Due to limitations in early iterations of Cairo, events had only one key corresponding to the event name. This lead to only being able to filter over all transfer events, which is far from ideal.
 
 ## Backward Compatability
 
-**This change is NOT backward compatible**. All DAPPs listenting to ERC20 transfer and approval events will have to adjust their events decoding, in order to look for fields in the `keys` array instead of in the `data` array.
+**This change is NOT backward compatible**. All DAPPs listening to ERC20 transfer and approval events will have to adjust their events decoding, in order to look for fields in the `keys` array instead of in the `data` array.
 
 ## Specification
 
-Starknet's json-rpc [`starknet_getEvents` method](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_api_openrpc.json#L798), takes an `EventFilter` object, which contains a nested list of keys to be matched against. For example, if the user sent an event filter containing $\big[[k_1, k_2], [\;], [k_3]\big]$, then the node should return events whose first key is $k_1$ or $k_2$, and the third key is $k_3$, and the second key is unconstrained and can take any value. This functionality is supported by variuous Starknet SDKs, for example, see the following [starknet.js tutorial](https://www.starknetjs.com/docs/guides/events#without-transaction-hash) to see how to filter events.
+Starknet's json-rpc [`starknet_getEvents` method](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_api_openrpc.json#L798), takes an `EventFilter` object, which contains a nested list of keys to be matched against. For example, if the user sent an event filter containing $\big[[k_1, k_2], [\;], [k_3]\big]$, then the node should return events whose first key is $k_1$ or $k_2$, and the third key is $k_3$, and the second key is unconstrained and can take any value. This functionality is supported by various Starknet SDKs, for example, see the following [starknet.js tutorial](https://www.starknetjs.com/docs/guides/events#without-transaction-hash) to see how to filter events.
 
 Currently, these are the `Transfer` and `Approval` events in all StarkGate's ERC20s:
 

--- a/SNIPS/snip-19.md
+++ b/SNIPS/snip-19.md
@@ -2,7 +2,7 @@
 snip: 19
 title: Contract Class Hash Syscall
 author: Elias Tazartes <@Eikix>
-description: Introduce a Starknet syscall to get to class hash at a particular address.
+description: Introduce a Starknet syscall to get class hash at a particular address.
 discussions-to: https://community.starknet.io/t/snip-19-get-class-hash-at-syscall
 status: Draft
 type: Standards Track

--- a/SNIPS/snip-22.md
+++ b/SNIPS/snip-22.md
@@ -33,7 +33,7 @@ All tokenized vaults MUST implement the SNIP-2 standard including its optional m
 
 The SNIP-2 operations `balance_of`, `transfer`, `total_supply`, etc. MUST operate on the vault shares.
 
-Calls to `transfer` or `transfer_from` MAY revert if vault shares are non-transferable or some conditions, required by the tokenized vault implementation, for a succesful transfer are not met.
+Calls to `transfer` or `transfer_from` MAY revert if vault shares are non-transferable or some conditions, required by the tokenized vault implementation, for a successful transfer are not met.
 
 The SNIP-2 optional operations `name` and `symbol` SHOULD reflect the underlying asset's `name` and `symbol` in some way.
 
@@ -152,7 +152,7 @@ Mints `shares` vault shares to `receiver` by depositing exactly `assets` of unde
 MUST emit the `Deposit` event.
 
 MUST support SNIP-2 `approve` / `transfer_From` on `asset` as a deposit flow.
-MAY support additoinal deposit flows.
+MAY support additional deposit flows.
 
 MUST revert if all of `assets` cannot be deposited (due to deposit limit being reached, slippage, the user not approving enough underlying tokens to the vault contract, etc).
 
@@ -275,7 +275,7 @@ fn max_redeem(self: @TContractState, owner: ContractAddress) -> u256
 
 #### preview_redeem
 
-Simulate the effects of a share redeemption, at the current block.
+Simulate the effects of a share redemption, at the current block.
 
 MUST return as close to and no more than the exact amount of assets that would be withdrawn in a `redeem` call in the same transaction. I.e. `redeem` should return the same or more `assets` as `preview_redeem` if called in the same transaction.
 


### PR DESCRIPTION
### Summary of Changes

**SNIPS/snip-13.md**
- `filteration ` → `filtering `
- `listenting ` → `listening `
- `variuous ` → `various `


**SNIPS/snip-19.md**
- `get to class hash` → `get class hash`

**SNIPS/snip-22.md**
- `succesful ` → `successful `
- `additoinal ` → `additional `
- `redeemption ` → `redemption `
