### PR TITLE
chore: correct typos docs

### DIFF
--- a/SNIPS/snip-5.md
+++ b/SNIPS/snip-5.md
@@ -98,7 +98,7 @@ The signature for a struct having `n` fields is: `(field1_type,field2_type,...)`
 
 The signature for an enum having `n` fields is: `E(variant1_type,variant2_type,...)`, where `variantN_type` is the type of the n-th enum variant.
 
-The leading `E` avoid clashes with similar signatures using tuples or structs.
+The leading `E` avoids clashes with similar signatures using tuples or structs.
 
 ### Examples
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -2,7 +2,7 @@
 snip: 6
 title: Standard Account Interface
 authors: Martín Triay <martriay@gmail.com>, Julien Niset <julien@argent.xyz>, Eric Nordelo <eric.nordelo39@gmail.com>, Sergio Garcia <sergio@argent.xyz>, Yoav Gaziel <yoav.gaziel@braavos.app>
-discussion-to: https://community.starknet.io/t/snip-starknet-standard-account/95665
+discussions-to: https://community.starknet.io/t/snip-starknet-standard-account/95665
 status: Review
 type: Standards Track
 category: SRC

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -2,7 +2,7 @@
 snip: 6
 title: Standard Account Interface
 authors: Martín Triay <martriay@gmail.com>, Julien Niset <julien@argent.xyz>, Eric Nordelo <eric.nordelo39@gmail.com>, Sergio Garcia <sergio@argent.xyz>, Yoav Gaziel <yoav.gaziel@braavos.app>
-discussions-to: https://community.starknet.io/t/snip-starknet-standard-account/95665
+discussion-to: https://community.starknet.io/t/snip-starknet-standard-account/95665
 status: Review
 type: Standards Track
 category: SRC


### PR DESCRIPTION
I reviewed the entire repository, no more typos found in docs. 
Hope this helps streamline the project!
Best regards,
Bilogweb3