### PR TITLE
SNIP-6 Update

### DIFF
--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -32,6 +32,51 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 **Every SNIP-6 compliant account MUST implement the `SRC6` and `SRC5` (from [SNIP-5](./snip-5.md)) interfaces**, and publish both interface ids through `supports_interface`:
 
+**The interface ID for an account is hardcoded to be `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. Note that that some methods have been changed since the first version but the interface ID won't change for compatibility purposes
+
+#### Current interface
+```cairo
+/// @title Represents a call to a target contract
+/// @param to The target contract address
+/// @param selector The target function selector
+/// @param calldata The serialized function parameters
+struct Call {
+    to: ContractAddress,
+    selector: felt252,
+    calldata: Span<felt252>
+}
+
+/// @title SRC-6 Standard Account
+trait ISRC6 {
+    /// @notice Execute a transaction through the account
+    /// @param calls The list of calls to execute
+    fn __execute__(calls: Array<Call>);
+
+    /// @notice Assert whether the transaction is valid to be executed
+    /// @param calls The list of calls to execute
+    /// @return The string 'VALID' represented as felt when is valid
+    fn __validate__(calls: Array<Call>) -> felt252;
+
+    /// @notice Assert whether a given signature for a given hash is valid
+    /// @param hash The hash of the data
+    /// @param signature The signature to validate
+    /// @return The string 'VALID' represented as felt when the signature is valid
+    fn is_valid_signature(hash: felt252, signature: Array<felt252>) -> felt252;
+}
+
+/// @title SRC-5 Standard Interface Detection
+trait ISRC5 {
+    /// @notice Query if a contract implements an interface
+    /// @param interface_id The interface identifier, as specified in SRC-5
+    /// @return `true` if the contract implements `interface_id`, `false` otherwise
+    fn supports_interface(interface_id: felt252) -> bool;
+}
+```
+
+
+
+#### Legacy interface used to calculate the [SRC5](./snip-5.md) interface ID
+
 ```cairo
 /// @title Represents a call to a target contract
 /// @param to The target contract address
@@ -60,14 +105,6 @@ trait ISRC6 {
     /// @param signature The signature to validate
     /// @return The string 'VALID' is represented as felt when the signature is valid
     fn is_valid_signature(hash: felt252, signature: Array<felt252>) -> felt252;
-}
-
-/// @title SRC-5 Standard Interface Detection
-trait ISRC5 {
-    /// @notice Query if a contract implements an interface
-    /// @param interface_id The interface identifier, as specified in SRC-5
-    /// @return `true` if the contract implements `interface_id`, `false` otherwise
-    fn supports_interface(interface_id: felt252) -> bool;
 }
 ```
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -128,7 +128,7 @@ At the same time, the standard is designed to be minimal and flexible, allowing 
 
 As mentioned before the interface ID for an account is always `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. 
 
-Note that the the current interface in and the legacy one are compatible in the way they can be called.
+Note that the the current interface id and the legacy one are compatible in the way they can be called.
 
 The latest `__execute__` execute methods returns no data. But older versions used to return the result of the calls. 3rd parties shouldn't rely on the data being returned
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -130,7 +130,7 @@ As mentioned before the interface ID for an account remains `0x2ceccef7f994940b3
 
 Note that the the current interface id and the legacy one are compatible in the way they can be called.
 
-The latest version of the `__execute__` method returns no data. But older versions used to return the result of the calls. Third parties shouldn't rely on the data being returned
+The latest version of the `__execute__` method returns no data. But older versions used to return the result of the calls. Third parties shouldn't rely on the data being returned.
 
 Currently, multiple accounts are using `bool` as the `is_valid_signature` return value. While in the future we expect that most of the accounts will migrate to this standard, in the meantime, we recommend dapps and protocols using this feature to check for both `true` or `'VALID'`.
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -123,6 +123,12 @@ Wallets are advised not to sign any data unless they know that it includes the a
 
 ## Backwards Compatibility
 
+As mentioned before the interface ID for an account is always `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. 
+
+Note that the the current interface in and the legacy one are compatible in the way they can be called.
+
+The latest `__execute__` execute methods returns no data. But older versions used to return the result of the calls. 3rd parties shouldn't rely on the data being returned
+
 Currently, multiple accounts are using `bool` as the `is_valid_signature` return value. While in the future we expect that most of the accounts will migrate to this standard, in the meantime, we recommend dapps and protocols using this feature to check for both `true` or `'VALID'`.
 
 ## Copyright

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -32,7 +32,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 **Every SNIP-6 compliant account MUST implement the `SRC6` and `SRC5` (from [SNIP-5](./snip-5.md)) interfaces**, and publish both interface ids through `supports_interface`:
 
-**The interface ID for an account is hardcoded to be `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. Note that that some methods have been changed since the first version but the interface ID won't change for compatibility purposes
+**The interface ID for an account is hardcoded to be `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. Note that some methods have changed since the first version, but the interface ID will not change to maintain compatibility.
 
 #### Current interface
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -126,7 +126,7 @@ At the same time, the standard is designed to be minimal and flexible, allowing 
 
 ## Backwards Compatibility
 
-As mentioned before the interface ID for an account is always `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. 
+As mentioned before the interface ID for an account remains `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. 
 
 Note that the the current interface id and the legacy one are compatible in the way they can be called.
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -35,6 +35,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 **The interface ID for an account is hardcoded to be `0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd`** which matches the original account interface. Note that that some methods have been changed since the first version but the interface ID won't change for compatibility purposes
 
 #### Current interface
+
 ```cairo
 /// @title Represents a call to a target contract
 /// @param to The target contract address

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -130,7 +130,7 @@ As mentioned before the interface ID for an account remains `0x2ceccef7f994940b3
 
 Note that the the current interface id and the legacy one are compatible in the way they can be called.
 
-The latest `__execute__` execute methods returns no data. But older versions used to return the result of the calls. 3rd parties shouldn't rely on the data being returned
+The latest version of the `__execute__` method returns no data. But older versions used to return the result of the calls. Third parties shouldn't rely on the data being returned
 
 Currently, multiple accounts are using `bool` as the `is_valid_signature` return value. While in the future we expect that most of the accounts will migrate to this standard, in the meantime, we recommend dapps and protocols using this feature to check for both `true` or `'VALID'`.
 

--- a/SNIPS/snip-6.md
+++ b/SNIPS/snip-6.md
@@ -119,7 +119,10 @@ Wallets are advised not to sign any data unless they know that it includes the a
 
 ## Rationale
 
-(To Do...)
+This SNIP aims to standardize the interface for accounts on Starknet. While some functions are required by Starknet itself for an account to function, this standard includes additional functionality that enhances an account's interoperability with the broader Starknet ecosystem.
+For example, the `is_valid_signature` function provides a standard way for dapps and protocols to verify signatures, making the account compatible with any dapp or protocol that expects this functionality. Adhering to the SNIP-5 also makes an account more easily discoverable and integrable.
+While an account on Starknet could function without adhering to this standard, doing so provides significant benefits in terms of interoperability, discoverability, and user experience. Accounts compliant with SNIP-6 can expect better compatibility and integration with the rest of the Starknet ecosystem.
+At the same time, the standard is designed to be minimal and flexible, allowing for a wide variety of account implementations.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Update SNIP-6 to make sure the SRC5 interface ID doesn't change even if we do some small changes to the SNIP. Otherwise it's a problem to check if a given contract is an account

This PR also reflects the changes from `Array` to `Span` that happened months ago when cairo was updated

Lastly. This introduces a change to the `__execute__` method. Today it returns the results of the calls. but the returned data is unusable. Specially since it’s now enforced that nobody can call  `__execute__` directly. It's wasteful to generate and return all this data for nothing. The change shouldn't break anything and it can improve the performance of Starknet