### PR TITLE
docs: fix typo in ERC721 error name

### DIFF
--- a/SNIPS/snip-64.md
+++ b/SNIPS/snip-64.md
@@ -290,7 +290,7 @@ mod ERC721ErrorsComponent {
 
         fn throw_insufficient_approval(self: @ComponentState<TContractState>, operator: ContractAddress, token_id: u256) {
             let data: Array<felt252> = array![
-                'ERC721InsufficientApprovel',
+                'ERC721InsufficientApproval',
                 operator.into(),
                 token_id.try_into().unwrap(),
             ];


### PR DESCRIPTION
I noticed a typo in the ERC721 errors.
The error `'ERC721InsufficientApprovel'` was incorrectly spelled. I've corrected it to `'ERC721InsufficientApproval'` to ensure consistency and accuracy in the error naming.