### PR TITLE
SNIP-12: revision 2 draft, reference encoder and test vectors

### DIFF
--- a/SNIPS/snip-12.md
+++ b/SNIPS/snip-12.md
@@ -492,6 +492,19 @@ A wallet, SDK or contract that does not implement a revision MUST reject a reque
 
 Note: Cartridge Controller's `execute_from_outside_v3` hashes its domain with the felt `2` in the `revision` slot while applying revision `1` rules and a `(felt,u128)` nonce type. Those signatures are not revision `2` messages; revision `2` deliberately uses `0x32` so that the two cannot collide.
 
+### Notation
+
+The rest of this section uses the following terms and nothing else for them.
+
+- `P`: the STARK field prime `2^251 + 17 * 2^192 + 1`. All felts are integers in `[0, P)`.
+- `hash_array(x_0, ..., x_n)`: the array hash defined under Hash functions. It maps a sequence of felts to one felt.
+- `encode_type(T)`: the *type string* of a struct or enum `T`, defined under encode_type. It is the only place where "encode" refers to a type.
+- `type_hash(T)`: `starknet_keccak(encode_type(T))`, a felt.
+- `Enc[x]`: the *encoding* of a value `x`, a sequence of felts. It is one felt for every value except a `u256`, which is two felts. Structs, enums, arrays and merkle trees always encode to exactly one felt. Whenever this section says the encoding of a value, it means `Enc[x]`.
+- `a || b`: concatenation of felt sequences.
+- *struct hash*: `Enc[x]` of a struct value; the *domain hash* is `Enc[domain]`; the *message hash* is the final felt that is signed, defined under Message hash.
+- `escape(name)`: the quoting of a name in a type string, defined under Names and escaping.
+
 ### Hash functions
 
 - `hash_array(x_0, ..., x_n)`: Poseidon over the sequence, as computed by Cairo's `core::poseidon::poseidon_hash_span` and cairo-lang's `poseidon_hash_many`. This is the only array hash used in revision `2`.
@@ -531,7 +544,7 @@ signed_data = hash_array('StarkNet Message', Enc[domain], account, Enc[message])
 
 - The `domain` object MUST contain exactly the fields declared in the `StarknetDomain` type: no missing fields, no undeclared fields.
 - `chainId` is the chain identifier as a shortstring, for example `"SN_MAIN"`. A wallet MUST reject a request whose `chainId` is not the chain it is connected to.
-- `verifyingContract` SHOULD be set to the contract that will verify the signature whenever there is one. It prevents two contracts that share a `name` and `version` from accepting each other's signatures.
+- `verifyingContract` SHOULD be set to the contract that will verify the signature whenever there is one. It prevents two contracts that share a `name` and `version` from accepting each other's signatures. It is optional rather than mandatory because one signature may legitimately authorise a workflow that spans several contracts, for example releasing liquidity from multiple pools; in that case the domain `name` and `version` carry the binding and the message itself should identify the contracts involved.
 - `salt` is an arbitrary felt for further disambiguation, as in EIP-712.
 
 The domain is hashed as a struct: `Enc[domain] = hash_array(type_hash(StarknetDomain), Enc[name], Enc[version], Enc[chainId], Enc[revision], ...)`.
@@ -584,7 +597,7 @@ Declared as in revision `1`: an array of `{ "name", "type" }` fields. A field ty
 Enc[x] = hash_array(type_hash(T), Enc[field_1], ..., Enc[field_n])
 ```
 
-where the field encodings are concatenated in declaration order (a `u256` field contributes two felts).
+where the `Enc` sequences of the fields are concatenated in declaration order (a `u256` field contributes two felts).
 
 #### User-defined enums
 
@@ -613,7 +626,7 @@ Enc[x] = hash_array(type_hash(E), variant_index, Enc[param_1], ..., Enc[param_k]
 Enc[(x_0, ..., x_n)] = hash_array(Enc[x_0] || ... || Enc[x_n])
 ```
 
-The element encodings are concatenated (so an array of `u256` hashes `2(n+1)` felts) and the array always encodes to a single felt. The empty array encodes as `hash_array()`.
+The `Enc` sequences of the elements are concatenated (so an array of `u256` hashes `2(n+1)` felts) and `Enc` of an array is always a single felt. `Enc` of the empty array is `hash_array()` of the empty sequence.
 
 #### Merkle tree
 
@@ -644,7 +657,7 @@ For an enum:
 
 Field and parameter types are written exactly as declared, including `*` suffixes, with no whitespace. A `merkletree` field is written as `"field":"merkletree"`.
 
-After the primary encoding, the encodings of every user-defined type it references, directly or transitively, are appended: types referenced by fields (through any number of `*`), by enum variant parameters, and by a `merkletree` field's `contains`. Referenced types are sorted by their names in byte order and each appears once. Basic types, including `u256`, are never appended.
+After the type string of `T` itself, the type strings of every user-defined type it references, directly or transitively, are appended: types referenced by fields (through any number of `*`), by enum variant parameters, and by a `merkletree` field's `contains`. Referenced types are sorted by their names in byte order and each appears once. Basic types, including `u256`, are never appended.
 
 Example, using the `Payment` types from the test vectors:
 
@@ -711,6 +724,7 @@ Implementations MAY additionally impose limits on document size, array length an
 3. Whether `verifyingContract` should be mandatory rather than optional.
 4. Whether the `'StarkNet Message'` prefix should become `'Starknet Message'`.
 5. Whether `string` should keep the `ByteArray` serialisation or move to a simpler `hash_array` over 31-byte chunks.
+6. Whether `hash_array` should be Blake2s instead of Poseidon. Starknet moved compiled-class hashes to Blake2s in v0.14.1 (SNIP-34) and OS program and config hashes in v0.14.3, because Blake is about 3x cheaper to prove with Stwo (8x on the CASM-hash component once batching is counted) and avoids Poseidon's post-quantum questions. Against it, for the contracts that verify SNIP-12 signatures: under the current fee schedule one Blake2s compression (64 bytes, which under the SNIP-34 felt encoding carries two large felts) costs 3,334 gas, against 491 gas plus three steps for one Poseidon permutation that also absorbs two felts, so roughly 4x per large felt; and Cairo contracts must first split every felt into u32 words without hints. A Cairo 2.18 measurement with a SNIP-34-compatible Blake felt hash (checked against starknet.js's `blake2sHashMany`) put a 32-felt hash at 10x to 30x the Poseidon cost, or about 2x when only the compression step is counted. SNIP-12 inputs are almost all large felts (type hashes, struct hashes, addresses), and every wallet, SDK, account contract and merkle library speaks Poseidon today. This draft keeps Poseidon. The question should be reopened if a felt-native Blake libfunc ships or the Poseidon builtin is repriced.
 
 ## Implementation
 

--- a/SNIPS/snip-12.md
+++ b/SNIPS/snip-12.md
@@ -79,6 +79,7 @@ This object ensures the uniqueness of messages based on:
 - **revision (optional)**: the revision of the specification to be used. If the value is omitted it will default to `0` .
     - Revision `0`: Represents the de facto spec before this SNIP was published. The purpose is to help with backwards compatibility. It’s not recommended to use it.
     - Revision `1`: Will be the initial version of the specification. Note that for this revision the value in this field should be the integer `1` and not the shortstring `"1"` despite being defined as shortstring. This exception is made to support an inconsistency in the Braavos wallet implementation. See the [example](#json-example) below.
+    - Revision `2`: Draft, see [Revision 2](#revision-2-draft) below. The value in this field is the shortstring `"2"`. Implementations MUST reject any revision they do not support.
 
 Introduced in revision `0`, changed in revision `1`  
 In revision `0` the fields `name` , `version` and `chainId` are of type `felt` .  
@@ -442,11 +443,280 @@ The request should be considered invalid
 ```
 **Note:** The value of the field `revision` is the integer `1` eventhough the type of the field is `shortstring`
 
+## Revision 2 (draft)
+
+> Status: **draft for discussion**. Revision `1` remains the active revision. Nothing in this section changes how revision `0` or revision `1` messages are hashed; deployed contracts that verify revision `1` signatures (including SNIP-9 `execute_from_outside_v2`) are unaffected.
+
+### Why a new revision
+
+Revision `1` has been in production since 2024 and the text and the shipped implementations have drifted apart in ways that break signature interoperability:
+
+- `u256` is defined as a preset struct, so the text implies `hash_array(type_hash(u256), low, high)`. starknet.js, starknet.py, starknet-rs and Argent's Cairo reference do this; OpenZeppelin's `StructHash` pattern flattens `low, high` because that is what Cairo's derived `Hash` does. ([starknet.js #1464](https://github.com/starknet-io/starknet.js/issues/1464), [SNIPs #176](https://github.com/starknet-io/SNIPs/issues/176))
+- Enum type strings: the text writes `"Variant"("u128")`; starknet.js, starknet.py and starknet-rs write `"Variant":("u128")`; OpenZeppelin's `type_hash` macro follows the text. ([starknet.js #1286](https://github.com/starknet-io/starknet.js/issues/1286), Zellic audit of OpenZeppelin Cairo Contracts v4, finding 3.13)
+- Enum values: the text includes `type_hash(enum)`; all three SDKs omit it, and starknet.js appends a `0` for a variant with no parameters. ([#1278](https://github.com/starknet-io/starknet.js/issues/1278), [#1341](https://github.com/starknet-io/starknet.js/issues/1341))
+- `shortstring` values that look like numbers are encoded as numbers (`"2"` becomes `0x2`), which is also what makes the integer `1` revision exception work. ([#1039](https://github.com/starknet-io/starknet.js/issues/1039))
+- `selector` values that look like hex are passed through unhashed, hiding the entrypoint name from the user. ([#1348](https://github.com/starknet-io/starknet.js/issues/1348))
+- `escape(name)` is "JSON escaping" in the text, no escaping in starknet.js and starknet.py, and full JSON escaping in starknet-rs and OpenZeppelin.
+- The merkle tree algorithm, the serialisation behind `string`, tuples, nested arrays, the treatment of extra or missing message fields, and what to do with an unknown revision are not defined. There are no test vectors, so every new implementation has been calibrated against starknet.js instead of the text.
+
+Revision `2` fixes these by specification rather than by patching libraries, because the revision `1` hashes are frozen in deployed account contracts.
+
+### Summary of changes from revision 1
+
+| Aspect | Revision 1 | Revision 2 |
+| --- | --- | --- |
+| `revision` value | integer `1` (typed `shortstring`) | JSON string `"2"`, encoded as the shortstring `0x32` |
+| Unknown revision | unspecified | MUST be rejected |
+| Domain fields | `name`, `version`, `chainId`, `revision` | same, plus optional `verifyingContract` and `salt` |
+| `chainId` | unspecified | MUST equal the chain the wallet is connected to |
+| Presets (`u256`, `TokenAmount`, `NftId`) | structs hashed with a type-hash prefix | `u256` is a basic type encoded as two felts; `TokenAmount` and `NftId` are ordinary user-defined structs (recommended shapes below) |
+| Enums | referenced as `"type": "enum", "contains": "E"` | referenced by name like structs: `"type": "E"` |
+| Enum type string | ambiguous | `"E"("V1"(),"V2"("u128","T"))`, no colon |
+| Enum value | ambiguous | `hash_array(type_hash(E), index, params...)`, nothing appended for an empty variant |
+| Integer types | `u128`, `i128` | `u8`..`u128`, `i8`..`i128`, `bytes31`; `timestamp` is `u64` |
+| `shortstring` | numeric strings become numbers | always the ASCII bytes |
+| `string` | `hash_array(serialise(x))` | Cairo `ByteArray` serialisation of the UTF-8 bytes, spelled out |
+| `selector` | hex passthrough in the reference implementation | always `starknet_keccak(name)`; value must be an identifier |
+| Names | JSON escaping | printable ASCII without `"` `\` `(` `)` `,` `:` `*`; escaping is quoting |
+| Tuples, `Option` | undefined | not allowed; model as structs |
+| Nested arrays | undefined | allowed (`T**`) |
+| Merkle tree | undefined | defined (sorted pairs, `hash_array`, odd node promoted) |
+| Validation | type-name rules only | full MUST-reject list, including undeclared and missing message fields |
+| Test vectors | none | `assets/snip-12/rev2/vectors.json` |
+
+### Revision selection
+
+The `revision` field of the domain MUST be the JSON string `"2"`. It is encoded like any other `shortstring`, i.e. as the felt `0x32`.
+
+A wallet, SDK or contract that does not implement a revision MUST reject a request carrying it. A revision `1` implementation that receives `"revision": "2"` MUST fail closed rather than hash the request with revision `1` rules.
+
+Note: Cartridge Controller's `execute_from_outside_v3` hashes its domain with the felt `2` in the `revision` slot while applying revision `1` rules and a `(felt,u128)` nonce type. Those signatures are not revision `2` messages; revision `2` deliberately uses `0x32` so that the two cannot collide.
+
+### Hash functions
+
+- `hash_array(x_0, ..., x_n)`: Poseidon over the sequence, as computed by Cairo's `core::poseidon::poseidon_hash_span` and cairo-lang's `poseidon_hash_many`. This is the only array hash used in revision `2`.
+- `type_hash(T) = starknet_keccak(encode_type(T))`, unchanged.
+- Merkle tree nodes use `hash_array` over the sorted pair (see below). The two-input `poseidon_hash(a, b)` variant is not used.
+
+### Message hash
+
+```
+signed_data = hash_array('StarkNet Message', Enc[domain], account, Enc[message])
+```
+
+`'StarkNet Message'` is the shortstring `0x537461726b4e6574204d657373616765`, `account` is the address of the signing account contract, `Enc[domain]` is the struct hash of the domain and `Enc[message]` the struct hash of the `primaryType` value. The prefix is unchanged from revisions `0` and `1`.
+
+### Domain separator
+
+```js
+"StarknetDomain": [
+  { "name": "name", "type": "shortstring" },
+  { "name": "version", "type": "shortstring" },
+  { "name": "chainId", "type": "shortstring" },
+  { "name": "revision", "type": "shortstring" },
+  { "name": "verifyingContract", "type": "ContractAddress" },   // optional
+  { "name": "salt", "type": "felt" }                            // optional
+]
+```
+
+- The first four fields are mandatory and MUST appear in this order with these names and types.
+- `verifyingContract` and `salt` are optional. When present they MUST appear after `revision`, in this order. Exactly four definitions of `StarknetDomain` are therefore valid; their type hashes are:
+
+| Fields | `type_hash(StarknetDomain)` |
+| --- | --- |
+| `name, version, chainId, revision` | `0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210` (identical to revision 1) |
+| `..., verifyingContract` | `0x22a208060c1d6c5515c9576d39d2b7c812e54202f1e05ea6428500efb4b6a8b` |
+| `..., salt` | `0xa6be7486d2812c36d3c878d0053106533675d70a104fe5600617305bcac793` |
+| `..., verifyingContract, salt` | `0x3d8dc39daf4e8de4ab71497d1947ca1e97d04084a7889c13434359080e3797f` |
+
+- The `domain` object MUST contain exactly the fields declared in the `StarknetDomain` type: no missing fields, no undeclared fields.
+- `chainId` is the chain identifier as a shortstring, for example `"SN_MAIN"`. A wallet MUST reject a request whose `chainId` is not the chain it is connected to.
+- `verifyingContract` SHOULD be set to the contract that will verify the signature whenever there is one. It prevents two contracts that share a `name` and `version` from accepting each other's signatures.
+- `salt` is an arbitrary felt for further disambiguation, as in EIP-712.
+
+The domain is hashed as a struct: `Enc[domain] = hash_array(type_hash(StarknetDomain), Enc[name], Enc[version], Enc[chainId], Enc[revision], ...)`.
+
+### Names and escaping
+
+Type names, field names and enum variant names:
+
+- MUST consist of printable ASCII characters (`0x20` to `0x7E`) only.
+- MUST NOT contain `"`, `\`, `(`, `)`, `,`, `:` or `*`.
+- MUST NOT be empty and MUST NOT start or end with a space.
+- Type names MUST NOT be a basic type name (below) and MUST NOT be `StarknetDomain` unless defining the domain.
+- Field names MUST be unique within a type.
+
+Because of these rules, `escape(name)` is simply `"` + `name` + `"`. There is no JSON escaping step and no non-ASCII text in type strings.
+
+### Types
+
+There are three kinds of types: basic types, user-defined structs and user-defined enums. There are no preset types.
+
+#### Basic types
+
+`Enc[x]` of a basic type is a sequence of felts: one felt for every type except `u256`, which is two.
+
+| Type | JSON value | Constraint | `Enc[x]` |
+| --- | --- | --- | --- |
+| `felt` | integer (JSON number, decimal string or `0x` string) | `0 <= x < P` | `x` |
+| `bool` | JSON `true` / `false` | | `1` / `0` |
+| `u8` `u16` `u32` `u64` `u128` | integer | `0 <= x < 2^bits` | `x` |
+| `i8` `i16` `i32` `i64` `i128` | integer | `-2^(bits-1) <= x < 2^(bits-1)` | `x` if `x >= 0`, else `P + x` |
+| `u256` | integer | `0 <= x < 2^256` | `x mod 2^128, x div 2^128` (two felts: low, high) |
+| `bytes31` | integer | `0 <= x < 2^248` | `x` |
+| `ContractAddress` | integer | `0 <= x < 2^251` | `x` |
+| `ClassHash` | integer | `0 <= x < 2^251` | `x` |
+| `timestamp` | integer | `0 <= x < 2^64`, seconds since the Unix epoch | `x` |
+| `shortstring` | JSON string | at most 31 printable ASCII characters | the big-endian bytes as a felt; `"2"` is `0x32`, `""` is `0` |
+| `string` | JSON string | any Unicode text | `hash_array(n, w_0, ..., w_{n-1}, pending, pending_len)` where the UTF-8 bytes are split into `n` full 31-byte words `w_i` and a `pending` word of `pending_len` bytes (Cairo `ByteArray` serialisation) |
+| `selector` | JSON string | a Cairo identifier: `^[A-Za-z_][A-Za-z0-9_]*$` | `starknet_keccak(x)` |
+| `merkletree` | JSON array of leaves | see below | the merkle root |
+
+Integers are never parsed from a `shortstring`, and a `shortstring` is never parsed as a number. A value of the wrong JSON kind (for example `"true"` for a `bool`, or a number for a `shortstring`) MUST be rejected.
+
+`P` is the STARK field prime `2^251 + 17 * 2^192 + 1`.
+
+#### User-defined structs
+
+Declared as in revision `1`: an array of `{ "name", "type" }` fields. A field type is a basic type, a user-defined type, or either followed by one or more `*` for arrays. A `merkletree` field additionally carries `"contains"`, the name of the user-defined struct or enum used for its leaves.
+
+```
+Enc[x] = hash_array(type_hash(T), Enc[field_1], ..., Enc[field_n])
+```
+
+where the field encodings are concatenated in declaration order (a `u256` field contributes two felts).
+
+#### User-defined enums
+
+Declared as an array of variants, each `{ "name", "type" }` where `type` is a parenthesised, comma-separated list of parameter types: `"()"`, `"(u128)"`, `"(u128,Other Struct*)"`. A type is an enum if and only if every field type is parenthesised; mixing is not allowed. Whitespace inside the parentheses is ignored.
+
+An enum is referenced from a struct or from another enum by its name, exactly like a struct: `{ "name": "Fee", "type": "Fee Mode" }`. The revision `1` form `"type": "enum", "contains": ...` is not valid in revision `2`.
+
+The value of an enum field is an object with exactly one key, the variant name, whose value is the array of parameter values:
+
+```json
+"Fee": { "Pay Fee": [ { "Fee Amount": ..., "Fee Receiver": "0x..." } ] }
+"Fee": { "No Fee": [] }
+```
+
+```
+Enc[x] = hash_array(type_hash(E), variant_index, Enc[param_1], ..., Enc[param_k])
+```
+
+`variant_index` is the zero-based position of the variant in the declaration. A variant with no parameters hashes as `hash_array(type_hash(E), variant_index)`.
+
+#### Arrays
+
+`T*` is an array of `T`; `T**` an array of arrays, and so on. The value is a JSON array.
+
+```
+Enc[(x_0, ..., x_n)] = hash_array(Enc[x_0] || ... || Enc[x_n])
+```
+
+The element encodings are concatenated (so an array of `u256` hashes `2(n+1)` felts) and the array always encodes to a single felt. The empty array encodes as `hash_array()`.
+
+#### Merkle tree
+
+A `merkletree` field lets a user sign a large list while the contract verifies only a root. The field MUST carry `"contains"` naming a user-defined struct or enum; the value is a JSON array of leaves of that type with at least one element.
+
+```
+leaf_i  = Enc[x_i]
+node(a, b) = hash_array(min(a, b), max(a, b))
+```
+
+The root is computed level by level from the leaves in the given order: adjacent nodes are combined with `node`, and when a level has an odd number of nodes the last one is carried unchanged to the next level. A single leaf is its own root. The wallet MUST receive and display all leaves and MUST recompute the root itself.
+
+`node` matches OpenZeppelin's `PoseidonCHasher` (`openzeppelin_merkle_tree`), so roots and proofs can be verified on-chain with that library.
+
+### encode_type
+
+For a struct:
+
+```
+"T"("field_1":"type_1",...,"field_n":"type_n")
+```
+
+For an enum:
+
+```
+"E"("variant_1"("type_a","type_b"),"variant_2"())
+```
+
+Field and parameter types are written exactly as declared, including `*` suffixes, with no whitespace. A `merkletree` field is written as `"field":"merkletree"`.
+
+After the primary encoding, the encodings of every user-defined type it references, directly or transitively, are appended: types referenced by fields (through any number of `*`), by enum variant parameters, and by a `merkletree` field's `contains`. Referenced types are sorted by their names in byte order and each appears once. Basic types, including `u256`, are never appended.
+
+Example, using the `Payment` types from the test vectors:
+
+```
+"Payment"("Payer":"ContractAddress","Fee":"Fee Mode")"Fee Mode"("No Fee"(),"Pay Fee"("Fee Transfer"),"Split"("u128","u128*"))"Fee Transfer"("Fee Amount":"TokenAmount","Fee Receiver":"ContractAddress")"TokenAmount"("token_address":"ContractAddress","amount":"u256")
+```
+
+### Validation
+
+A conforming implementation MUST reject a request, before signing or hashing, when any of the following holds:
+
+1. `domain.revision` is not the JSON string `"2"`.
+2. `types.StarknetDomain` is not one of the four definitions above, or the `domain` object does not have exactly the declared fields.
+3. `domain.chainId` is not the chain the wallet is connected to (wallets).
+4. `primaryType` is `StarknetDomain` or is not declared in `types`.
+5. A type name or field name violates the naming rules, a type name is a basic type name, or a type declares two fields with the same name.
+6. A field or variant parameter references a type that is neither basic nor declared; a `merkletree` field lacks `contains`, or `contains` is not a user-defined struct or enum.
+7. A field type is a tuple, or a type mixes struct fields and enum variants.
+8. A declared type (other than `StarknetDomain`) is not reachable from `primaryType`, or type references form a cycle.
+9. The `message`, or any nested struct value, has a field that is not declared or lacks a declared field.
+10. A value has the wrong JSON kind, is outside its type's range, is not a valid `selector` identifier, or is a `shortstring` longer than 31 bytes or containing non-printable or non-ASCII characters.
+11. An enum value does not have exactly one key, names an undeclared variant, or supplies the wrong number of parameters.
+12. A `merkletree` value is empty.
+
+Implementations MAY additionally impose limits on document size, array length and nesting depth, and MUST reject rather than truncate when a limit is exceeded.
+
+### Wallet requirements
+
+- The wallet MUST display every field of the `message`, including every merkle leaf, and MUST NOT display anything that is not part of the hashed data. Two documents that display differently MUST hash differently.
+- `selector`, `ContractAddress`, `ClassHash`, `timestamp`, `TokenAmount` and `NftId` values SHOULD be rendered in a user-meaningful form (entrypoint name, resolved name or checksummed address, date and time, token symbol and decimals).
+- The wallet MUST show the domain `name`, `chainId` and, when present, `verifyingContract`.
+
+### Recommended structs for display
+
+`TokenAmount` and `NftId` are no longer preset types, but wallets are encouraged to recognise user-defined types with exactly these definitions and render them accordingly:
+
+```js
+"TokenAmount": [
+  { "name": "token_address", "type": "ContractAddress" },
+  { "name": "amount", "type": "u256" }
+],
+"NftId": [
+  { "name": "collection_address", "type": "ContractAddress" },
+  { "name": "token_id", "type": "u256" }
+]
+```
+
+### Test vectors
+
+`assets/snip-12/rev2/vectors.json` contains valid documents with their `encode_type` strings, type hashes, domain hash, struct hash and message hash for the account `0x1234`, and documents that MUST be rejected with the rule they violate. `assets/snip-12/rev2/encoder.mjs` is the reference encoder that produced them and can verify any implementation's output: `node encoder.mjs verify vectors.json`. Implementations claiming revision `2` support SHOULD pass every vector.
+
+### Relationship to revision 1 and migration
+
+- Revision `1` is unchanged and remains valid. Its hashes are hard-coded in deployed account contracts through SNIP-9 `execute_from_outside_v2`, so its rules cannot be corrected in place. Implementers should treat the revision `1` behaviour of starknet.js as the de-facto reference where the revision `1` text is ambiguous (enum colon, enum value without type hash, nested `u256`, numeric short strings), pending a separate clarification of the revision `1` text.
+- Dapps whose contracts verify signatures through `is_valid_signature(hash, signature)` can adopt revision `2` independently of account contract upgrades: only the dapp's hashing code and the wallet need to support it.
+- Standards that embed SNIP-12 hashing in account contracts (SNIP-9, SNIP-29) should define their next version on revision `2` rather than revision `1`, so that the enum, `u256` and tuple ambiguities are not frozen into account code a second time.
+
+### Open questions for review
+
+1. `u256` flattened as two felts (this draft) or nested with a type-hash prefix as in the revision `1` text.
+2. Enum type string without a colon (this draft, matching the revision `1` text and OpenZeppelin) or with the colon that starknet.js, starknet.py and starknet-rs ship.
+3. Whether `verifyingContract` should be mandatory rather than optional.
+4. Whether the `'StarkNet Message'` prefix should become `'Starknet Message'`.
+5. Whether `string` should keep the `ByteArray` serialisation or move to a simpler `hash_array` over 31-byte chunks.
+
 ## Implementation
 
-Find here an example repository for more detailed examples.  
+Revision `0` and `1`: find here an example repository for more detailed examples.  
 Note that this implementation uses Pedersen as the hashing function.  
 https://github.com/argentlabs/starknet-off-chain-signature
+
+Revision `2` (draft): the reference encoder and the test vectors live in [`assets/snip-12/rev2/`](../assets/snip-12/rev2/). The encoder implements the text of the Revision 2 section directly and depends on starknet.js only for the Poseidon and `starknet_keccak` primitives.
 
 ## References
 
@@ -458,7 +728,15 @@ https://github.com/argentlabs/starknet-off-chain-signature
 
 ## Security Considerations
 
-This SNIP has no impact at all in terms of security.
+Off-chain signatures authorise actions without a transaction, so the hash the user signs must bind exactly what the user saw and nothing else. Implementers should consider the following.
+
+- **Replay across domains.** The domain separator binds a signature to a dapp `name`, `version` and `chainId`. Two contracts that share a `name` and `version` accept each other's signatures unless `verifyingContract` (revision `2`) is set. Wallets MUST refuse a `chainId` that is not the connected chain; otherwise a signature requested on one network can be replayed on another.
+- **Replay across accounts and against transactions.** The `account` address in the outer hash prevents reuse of a signature by another account controlled by the same key. The `'StarkNet Message'` prefix separates off-chain messages from transaction hashes.
+- **Display and hash divergence.** Anything the wallet shows must be part of the hash and vice versa. Accepting undeclared message fields, passing `selector` values through unhashed, or letting a user-defined type shadow a built-in type name lets two different documents hash identically or hides the real meaning of a field. Revision `2` makes these rejections normative.
+- **Unknown revisions.** An implementation that hashes an unknown revision with the rules it knows produces a signature the user did not intend. Unknown revisions MUST be rejected.
+- **Blind hashes.** Some signers, including hardware wallets, receive only the final hash. Nothing in this SNIP protects a user whose signer cannot parse the typed data; such flows should be treated as blind signing.
+- **Nonces and expiry are the application's job.** This SNIP defines hashing only. Protocols that consume signatures (SNIP-9, SNIP-29, session keys) must define their own replay protection and time bounds.
+- **Resource limits.** Deeply nested or very large documents can exhaust a wallet or a contract. Implementations MAY impose limits and MUST fail closed when they do.
 
 ## Copyright
 

--- a/SNIPS/snip-12.md
+++ b/SNIPS/snip-12.md
@@ -478,7 +478,7 @@ Revision `2` fixes these by specification rather than by patching libraries, bec
 | `string` | `hash_array(serialise(x))` | Cairo `ByteArray` serialisation of the UTF-8 bytes, spelled out |
 | `selector` | hex passthrough in the reference implementation | always `starknet_keccak(name)`; value must be an identifier |
 | Names | JSON escaping | printable ASCII without `"` `\` `(` `)` `,` `:` `*`; escaping is quoting |
-| Tuples, `Option` | undefined | not allowed; model as structs |
+| Tuples, `Option` | undefined | not expressible: a type whose field types are all parenthesised is an enum; model tuple-like data as structs |
 | Nested arrays | undefined | allowed (`T**`) |
 | Merkle tree | undefined | defined (sorted pairs, `hash_array`, odd node promoted) |
 | Validation | type-name rules only | full MUST-reject list, including undeclared and missing message fields |
@@ -578,7 +578,7 @@ Integers are never parsed from a `shortstring`, and a `shortstring` is never par
 
 #### User-defined structs
 
-Declared as in revision `1`: an array of `{ "name", "type" }` fields. A field type is a basic type, a user-defined type, or either followed by one or more `*` for arrays. A `merkletree` field additionally carries `"contains"`, the name of the user-defined struct or enum used for its leaves.
+Declared as in revision `1`: an array of `{ "name", "type" }` fields. A field type is a basic type, a user-defined type, or either followed by one or more `*` for arrays. A `merkletree` field additionally carries `"contains"`, the name of the user-defined struct or enum used for its leaves. No other field may carry `"contains"`.
 
 ```
 Enc[x] = hash_array(type_hash(T), Enc[field_1], ..., Enc[field_n])
@@ -588,7 +588,7 @@ where the field encodings are concatenated in declaration order (a `u256` field 
 
 #### User-defined enums
 
-Declared as an array of variants, each `{ "name", "type" }` where `type` is a parenthesised, comma-separated list of parameter types: `"()"`, `"(u128)"`, `"(u128,Other Struct*)"`. A type is an enum if and only if every field type is parenthesised; mixing is not allowed. Whitespace inside the parentheses is ignored.
+Declared as an array of variants, each `{ "name", "type" }` where `type` is a parenthesised, comma-separated list of parameter types: `"()"`, `"(u128)"`, `"(u128,Other Struct*)"`. A type is an enum if and only if every field type is parenthesised. There is no tuple type: a type whose field types are all parenthesised is an enum with one variant per field, and a type with some parenthesised and some plain field types is malformed and MUST be rejected. Tuple-like data is modelled as a struct. Whitespace inside the parentheses is ignored.
 
 An enum is referenced from a struct or from another enum by its name, exactly like a struct: `{ "name": "Fee", "type": "Fee Mode" }`. The revision `1` form `"type": "enum", "contains": ...` is not valid in revision `2`.
 
@@ -659,12 +659,12 @@ A conforming implementation MUST reject a request, before signing or hashing, wh
 1. `domain.revision` is not the JSON string `"2"`.
 2. `types.StarknetDomain` is not one of the four definitions above, or the `domain` object does not have exactly the declared fields.
 3. `domain.chainId` is not the chain the wallet is connected to (wallets).
-4. `primaryType` is `StarknetDomain` or is not declared in `types`.
+4. `primaryType` is `StarknetDomain`, is not declared in `types`, or is not a struct.
 5. A type name or field name violates the naming rules, a type name is a basic type name, or a type declares two fields with the same name.
-6. A field or variant parameter references a type that is neither basic nor declared; a `merkletree` field lacks `contains`, or `contains` is not a user-defined struct or enum.
-7. A field type is a tuple, or a type mixes struct fields and enum variants.
+6. A field or variant parameter references a type that is neither basic nor declared; a `merkletree` field lacks `contains`, or its `contains` is not a user-defined struct or enum; or a field that is not a `merkletree` carries `contains`.
+7. A type mixes struct fields and enum variants (some field types parenthesised, some not).
 8. A declared type (other than `StarknetDomain`) is not reachable from `primaryType`, or type references form a cycle.
-9. The `message`, or any nested struct value, has a field that is not declared or lacks a declared field.
+9. The `message`, or any nested struct value, has an undeclared field or lacks a declared field.
 10. A value has the wrong JSON kind, is outside its type's range, is not a valid `selector` identifier, or is a `shortstring` longer than 31 bytes or containing non-printable or non-ASCII characters.
 11. An enum value does not have exactly one key, names an undeclared variant, or supplies the wrong number of parameters.
 12. A `merkletree` value is empty.
@@ -673,9 +673,11 @@ Implementations MAY additionally impose limits on document size, array length an
 
 ### Wallet requirements
 
-- The wallet MUST display every field of the `message`, including every merkle leaf, and MUST NOT display anything that is not part of the hashed data. Two documents that display differently MUST hash differently.
+- The wallet MUST display every field of the `message`, including every merkle leaf.
+- The wallet MUST NOT display anything that is not part of the hashed data.
 - `selector`, `ContractAddress`, `ClassHash`, `timestamp`, `TokenAmount` and `NftId` values SHOULD be rendered in a user-meaningful form (entrypoint name, resolved name or checksummed address, date and time, token symbol and decimals).
 - The wallet MUST show the domain `name`, `chainId` and, when present, `verifyingContract`.
+- Two documents that display differently MUST hash differently. A derived form that is not unique, such as a token symbol or a resolved name, MUST be shown alongside the underlying value, or not used at all.
 
 ### Recommended structs for display
 

--- a/SNIPS/snip-12.md
+++ b/SNIPS/snip-12.md
@@ -519,7 +519,7 @@ signed_data = hash_array('StarkNet Message', Enc[domain], account, Enc[message])
 ]
 ```
 
-- The first four fields are mandatory and MUST appear in this order with these names and types.
+- The first four fields are mandatory and MUST appear in this order with these names and types. The order of keys inside a field descriptor (`name`, `type`) is not significant.
 - `verifyingContract` and `salt` are optional. When present they MUST appear after `revision`, in this order. Exactly four definitions of `StarknetDomain` are therefore valid; their type hashes are:
 
 | Fields | `type_hash(StarknetDomain)` |
@@ -568,17 +568,17 @@ There are three kinds of types: basic types, user-defined structs and user-defin
 | `ClassHash` | integer | `0 <= x < 2^251` | `x` |
 | `timestamp` | integer | `0 <= x < 2^64`, seconds since the Unix epoch | `x` |
 | `shortstring` | JSON string | at most 31 printable ASCII characters | the big-endian bytes as a felt; `"2"` is `0x32`, `""` is `0` |
-| `string` | JSON string | any Unicode text | `hash_array(n, w_0, ..., w_{n-1}, pending, pending_len)` where the UTF-8 bytes are split into `n` full 31-byte words `w_i` and a `pending` word of `pending_len` bytes (Cairo `ByteArray` serialisation) |
+| `string` | JSON string | well-formed Unicode text (no unpaired surrogates) | `hash_array(n, w_0, ..., w_{n-1}, pending, pending_len)` where the UTF-8 bytes are split into `n` full 31-byte words `w_i` and a `pending` word of `pending_len` bytes (Cairo `ByteArray` serialisation) |
 | `selector` | JSON string | a Cairo identifier: `^[A-Za-z_][A-Za-z0-9_]*$` | `starknet_keccak(x)` |
 | `merkletree` | JSON array of leaves | see below | the merkle root |
 
-Integers are never parsed from a `shortstring`, and a `shortstring` is never parsed as a number. A value of the wrong JSON kind (for example `"true"` for a `bool`, or a number for a `shortstring`) MUST be rejected.
+An integer given as a JSON number MUST be a whole number with magnitude at most `2^53 - 1`, the range every JSON parser preserves exactly; larger values MUST be given as decimal or `0x` strings. Integers are never parsed from a `shortstring`, and a `shortstring` is never parsed as a number. A value of the wrong JSON kind (for example `"true"` for a `bool`, or a number for a `shortstring`) MUST be rejected.
 
 `P` is the STARK field prime `2^251 + 17 * 2^192 + 1`.
 
 #### User-defined structs
 
-Declared as in revision `1`: an array of `{ "name", "type" }` fields. A field type is a basic type, a user-defined type, or either followed by one or more `*` for arrays. A `merkletree` field additionally carries `"contains"`, the name of the user-defined struct or enum used for its leaves. No other field may carry `"contains"`.
+Declared as in revision `1`: an array of `{ "name", "type" }` fields. A field type is a basic type, a user-defined type, or either followed by one or more `*` for arrays. A `merkletree` field additionally carries `"contains"`, the name of the user-defined struct or enum used for its leaves. No other field may carry `"contains"`, and a field descriptor MUST NOT carry any key other than `name`, `type` and `contains`.
 
 ```
 Enc[x] = hash_array(type_hash(T), Enc[field_1], ..., Enc[field_n])
@@ -660,12 +660,12 @@ A conforming implementation MUST reject a request, before signing or hashing, wh
 2. `types.StarknetDomain` is not one of the four definitions above, or the `domain` object does not have exactly the declared fields.
 3. `domain.chainId` is not the chain the wallet is connected to (wallets).
 4. `primaryType` is `StarknetDomain`, is not declared in `types`, or is not a struct.
-5. A type name or field name violates the naming rules, a type name is a basic type name, or a type declares two fields with the same name.
+5. A type name or field name violates the naming rules, a type name is a basic type name, a type declares two fields with the same name, or a field descriptor carries a key other than `name`, `type` and (for `merkletree` fields) `contains`.
 6. A field or variant parameter references a type that is neither basic nor declared; a `merkletree` field lacks `contains`, or its `contains` is not a user-defined struct or enum; or a field that is not a `merkletree` carries `contains`.
 7. A type mixes struct fields and enum variants (some field types parenthesised, some not).
 8. A declared type (other than `StarknetDomain`) is not reachable from `primaryType`, or type references form a cycle.
 9. The `message`, or any nested struct value, has an undeclared field or lacks a declared field.
-10. A value has the wrong JSON kind, is outside its type's range, is not a valid `selector` identifier, or is a `shortstring` longer than 31 bytes or containing non-printable or non-ASCII characters.
+10. A value has the wrong JSON kind, is outside its type's range, is a JSON number that is not a whole number within `+/-(2^53 - 1)`, is not a valid `selector` identifier, is a `shortstring` longer than 31 bytes or containing non-printable or non-ASCII characters, or is a `string` containing an unpaired surrogate.
 11. An enum value does not have exactly one key, names an undeclared variant, or supplies the wrong number of parameters.
 12. A `merkletree` value is empty.
 

--- a/assets/snip-12/rev2/README.md
+++ b/assets/snip-12/rev2/README.md
@@ -1,0 +1,14 @@
+# SNIP-12 revision 2: reference encoder and test vectors (draft)
+
+- `vectors.json`: valid documents with their `encode_type` strings, type hashes, domain hash, struct hash and message hash for the account `0x1234`, plus documents that MUST be rejected and the rule each violates.
+- `encoder.mjs`: reference encoder implementing the Revision 2 section of `SNIPS/snip-12.md` rule by rule. It uses starknet.js only for Poseidon and `starknet_keccak`.
+- `vectors-src.mjs`: the documents from which `vectors.json` is generated.
+
+```bash
+npm install
+npm run verify      # recompute every vector and compare
+npm run generate    # regenerate vectors.json after changing vectors-src.mjs
+node encoder.mjs hash some-typed-data.json 0x1234
+```
+
+To check another implementation, feed it each `typed_data` under `vectors` with the `account` and compare against `expected`, then confirm it rejects every entry under `invalid`.

--- a/assets/snip-12/rev2/encoder.mjs
+++ b/assets/snip-12/rev2/encoder.mjs
@@ -126,9 +126,8 @@ export function validateTypedData(td) {
   // Domain definition must be one of the allowed shapes, in order.
   const domDef = types[DOMAIN_TYPE];
   if (!Array.isArray(domDef)) throw new Error(`missing ${DOMAIN_TYPE} type`);
-  const allowed = allowedDomainDefinitions();
-  const domKey = JSON.stringify(domDef);
-  if (!allowed.some((d) => JSON.stringify(d) === domKey)) throw new Error(`${DOMAIN_TYPE} definition is not one of the allowed shapes`);
+  const sameDefinition = (a, b) => a.length === b.length && a.every((f, i) => f && f.name === b[i].name && f.type === b[i].type);
+  if (!allowedDomainDefinitions().some((d) => sameDefinition(domDef, d))) throw new Error(`${DOMAIN_TYPE} definition is not one of the allowed shapes`);
   checkObjectKeys(domain, domDef.map((f) => f.name), 'domain');
 
   if (primaryType === DOMAIN_TYPE) throw new Error('primaryType cannot be the domain');
@@ -143,6 +142,9 @@ export function validateTypedData(td) {
     const seen = new Set();
     const isEnum = isEnumDefinition(def);
     for (const field of def) {
+      if (typeof field !== 'object' || field === null) throw new Error(`type ${name}: field descriptor must be an object`);
+      const extraKeys = Object.keys(field).filter((k) => !['name', 'type', 'contains'].includes(k));
+      if (extraKeys.length) throw new Error(`type ${name}: field descriptor has unknown key(s) ${extraKeys.join(', ')}`);
       checkName(field.name, `field of ${name}`);
       if (seen.has(field.name)) throw new Error(`duplicate field ${field.name} in ${name}`);
       seen.add(field.name);
@@ -252,7 +254,7 @@ export function typeHash(types, typeName) {
 
 function parseInteger(value, what) {
   if (typeof value === 'number') {
-    if (!Number.isSafeInteger(value)) throw new Error(`${what}: number is not a safe integer`);
+    if (!Number.isSafeInteger(value)) throw new Error(`${what}: JSON numbers must be whole and within +/-(2^53 - 1); use a decimal or 0x string for larger values`);
     return BigInt(value);
   }
   if (typeof value === 'string') {
@@ -287,6 +289,7 @@ function encodeBasic(type, value, what) {
       return [starknetKeccak(value)];
     case 'string':
       if (typeof value !== 'string') throw new Error(`${what}: string must be a JSON string`);
+      if (!value.isWellFormed()) throw new Error(`${what}: string contains an unpaired surrogate`);
       return [encodeByteArray(value)];
     case 'u256': {
       const v = inRange(parseInteger(value, what), 0n, 2n ** 256n - 1n, what);

--- a/assets/snip-12/rev2/encoder.mjs
+++ b/assets/snip-12/rev2/encoder.mjs
@@ -1,0 +1,443 @@
+// SNIP-12 revision 2 reference encoder (draft).
+//
+// This file exists to make the revision 2 text executable: it implements the
+// rules exactly as written in SNIPS/snip-12.md ("Revision 2") and is used to
+// generate and verify assets/snip-12/rev2/vectors.json.
+//
+// It is NOT a production library. It depends on starknet.js only for the
+// cryptographic primitives (Poseidon, starknet_keccak); every SNIP-12 rule is
+// implemented here so that the spec, not a library, is the reference.
+//
+//   node encoder.mjs generate > vectors.json
+//   node encoder.mjs verify vectors.json
+//   node encoder.mjs hash typed_data.json <account>
+
+import { readFileSync } from 'node:fs';
+import { hash as snHash } from 'starknet';
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+export const PRIME = 2n ** 251n + 17n * 2n ** 192n + 1n;
+const ADDRESS_BOUND = 2n ** 251n;
+export const PREFIX_MESSAGE = 'StarkNet Message';
+export const REVISION = '2';
+
+const toHex = (x) => '0x' + BigInt(x).toString(16);
+
+/** hash_array: Poseidon over a sequence of felts (Cairo `poseidon_hash_span`). */
+export function hashArray(felts) {
+  return BigInt(snHash.computePoseidonHashOnElements(felts.map((f) => BigInt(f))));
+}
+
+/** type_hash = starknet_keccak(encode_type) */
+export function starknetKeccak(str) {
+  return BigInt(snHash.starknetKeccak(str));
+}
+
+/** Encode an ASCII string of at most 31 bytes as a felt (big-endian bytes). */
+export function shortStringToFelt(s) {
+  if (s.length > 31) throw new Error(`shortstring longer than 31 bytes: ${JSON.stringify(s)}`);
+  let v = 0n;
+  for (const ch of s) {
+    const c = ch.codePointAt(0);
+    if (c < 0x20 || c > 0x7e) throw new Error(`shortstring must be printable ASCII: ${JSON.stringify(s)}`);
+    v = (v << 8n) | BigInt(c);
+  }
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const UNSIGNED = { u8: 8n, u16: 16n, u32: 32n, u64: 64n, u128: 128n, timestamp: 64n };
+const SIGNED = { i8: 8n, i16: 16n, i32: 32n, i64: 64n, i128: 128n };
+
+export const BASIC_TYPES = new Set([
+  'felt', 'bool', 'string', 'shortstring', 'selector', 'merkletree',
+  'ContractAddress', 'ClassHash', 'bytes31', 'u256',
+  ...Object.keys(UNSIGNED), ...Object.keys(SIGNED),
+]);
+
+export const DOMAIN_TYPE = 'StarknetDomain';
+const DOMAIN_REQUIRED = [
+  { name: 'name', type: 'shortstring' },
+  { name: 'version', type: 'shortstring' },
+  { name: 'chainId', type: 'shortstring' },
+  { name: 'revision', type: 'shortstring' },
+];
+const DOMAIN_OPTIONAL = [
+  { name: 'verifyingContract', type: 'ContractAddress' },
+  { name: 'salt', type: 'felt' },
+];
+
+const FORBIDDEN_NAME_CHARS = new Set(['"', '\\', '(', ')', ',', ':', '*']);
+
+function checkName(name, what) {
+  if (typeof name !== 'string' || name.length === 0) throw new Error(`${what}: empty name`);
+  if (name !== name.trim()) throw new Error(`${what}: name has leading or trailing whitespace: ${JSON.stringify(name)}`);
+  for (const ch of name) {
+    const c = ch.codePointAt(0);
+    if (c < 0x20 || c > 0x7e || FORBIDDEN_NAME_CHARS.has(ch)) {
+      throw new Error(`${what}: character not allowed in name: ${JSON.stringify(name)}`);
+    }
+  }
+}
+
+/** escape(name): revision 2 restricts names so that escaping is quoting. */
+export function escapeName(name) {
+  return `"${name}"`;
+}
+
+function stripArray(type) {
+  let t = type;
+  let depth = 0;
+  while (t.endsWith('*')) { t = t.slice(0, -1); depth += 1; }
+  return { base: t, depth };
+}
+
+function isEnumDefinition(def) {
+  return def.length > 0 && def.every((f) => f.type.startsWith('(') && f.type.endsWith(')'));
+}
+
+function variantParams(type) {
+  const inner = type.slice(1, -1).trim();
+  if (inner === '') return [];
+  return inner.split(',').map((s) => s.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Structural validation (the "MUST reject" list of the spec)
+// ---------------------------------------------------------------------------
+
+export function validateTypedData(td) {
+  if (typeof td !== 'object' || td === null) throw new Error('typed data must be an object');
+  const { types, primaryType, domain, message } = td;
+  if (typeof types !== 'object' || types === null) throw new Error('missing types');
+  if (typeof primaryType !== 'string') throw new Error('missing primaryType');
+  if (typeof domain !== 'object' || domain === null) throw new Error('missing domain');
+  if (typeof message !== 'object' || message === null) throw new Error('missing message');
+
+  // Revision gate.
+  if (domain.revision !== REVISION) throw new Error(`unsupported revision: ${JSON.stringify(domain.revision)}`);
+
+  // Domain definition must be one of the allowed shapes, in order.
+  const domDef = types[DOMAIN_TYPE];
+  if (!Array.isArray(domDef)) throw new Error(`missing ${DOMAIN_TYPE} type`);
+  const allowed = allowedDomainDefinitions();
+  const domKey = JSON.stringify(domDef);
+  if (!allowed.some((d) => JSON.stringify(d) === domKey)) throw new Error(`${DOMAIN_TYPE} definition is not one of the allowed shapes`);
+  checkObjectKeys(domain, domDef.map((f) => f.name), 'domain');
+
+  if (primaryType === DOMAIN_TYPE) throw new Error('primaryType cannot be the domain');
+  if (!types[primaryType]) throw new Error(`unknown primaryType ${primaryType}`);
+
+  // Type definitions.
+  for (const [name, def] of Object.entries(types)) {
+    checkName(name, 'type');
+    if (BASIC_TYPES.has(name)) throw new Error(`type name is reserved: ${name}`);
+    if (!Array.isArray(def) || def.length === 0) throw new Error(`type ${name} must be a non-empty array of fields`);
+    const seen = new Set();
+    const isEnum = isEnumDefinition(def);
+    for (const field of def) {
+      checkName(field.name, `field of ${name}`);
+      if (seen.has(field.name)) throw new Error(`duplicate field ${field.name} in ${name}`);
+      seen.add(field.name);
+      if (typeof field.type !== 'string' || field.type.length === 0) throw new Error(`field ${name}.${field.name} has no type`);
+      const paren = field.type.startsWith('(');
+      if (isEnum !== paren) throw new Error(`type ${name} mixes struct fields and enum variants`);
+      const refs = isEnum ? variantParams(field.type) : [field.type];
+      for (const ref of refs) {
+        const { base } = stripArray(ref);
+        if (base === 'merkletree') {
+          if (isEnum) throw new Error(`merkletree cannot be an enum variant parameter (${name})`);
+          if (!field.contains || !types[field.contains]) throw new Error(`merkletree field ${name}.${field.name} needs "contains" naming a user-defined type`);
+          if (ref !== 'merkletree') throw new Error(`arrays of merkletree are not allowed (${name}.${field.name})`);
+        } else if (!BASIC_TYPES.has(base) && !types[base]) {
+          throw new Error(`unknown type ${ref} in ${name}.${field.name}`);
+        }
+        if (base === DOMAIN_TYPE) throw new Error(`${DOMAIN_TYPE} cannot be referenced from ${name}`);
+      }
+    }
+  }
+
+  // Every user type must be reachable from primaryType (no dangling types) and no cycles.
+  const reachable = new Set();
+  const visiting = new Set();
+  const visit = (t) => {
+    if (reachable.has(t)) return;
+    if (visiting.has(t)) throw new Error(`recursive type definition involving ${t}`);
+    visiting.add(t);
+    for (const d of directDependencies(types, t)) visit(d);
+    visiting.delete(t);
+    reachable.add(t);
+  };
+  visit(primaryType);
+  for (const name of Object.keys(types)) {
+    if (name !== DOMAIN_TYPE && !reachable.has(name)) throw new Error(`dangling type ${name}`);
+  }
+  return true;
+}
+
+function checkObjectKeys(obj, expected, what) {
+  const keys = Object.keys(obj);
+  for (const k of expected) if (!(k in obj)) throw new Error(`${what}: missing field ${k}`);
+  for (const k of keys) if (!expected.includes(k)) throw new Error(`${what}: undeclared field ${k}`);
+}
+
+export function allowedDomainDefinitions() {
+  const [vc, salt] = DOMAIN_OPTIONAL;
+  return [
+    [...DOMAIN_REQUIRED],
+    [...DOMAIN_REQUIRED, vc],
+    [...DOMAIN_REQUIRED, salt],
+    [...DOMAIN_REQUIRED, vc, salt],
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// encode_type
+// ---------------------------------------------------------------------------
+
+function directDependencies(types, typeName) {
+  const def = types[typeName];
+  const deps = new Set();
+  const isEnum = isEnumDefinition(def);
+  for (const field of def) {
+    const refs = isEnum ? variantParams(field.type) : [field.type];
+    for (const ref of refs) {
+      const { base } = stripArray(ref);
+      if (base === 'merkletree') deps.add(field.contains);
+      else if (types[base]) deps.add(base);
+    }
+  }
+  return deps;
+}
+
+function encodeSingleType(types, typeName) {
+  const def = types[typeName];
+  if (isEnumDefinition(def)) {
+    const variants = def.map((v) => `${escapeName(v.name)}(${variantParams(v.type).map(escapeName).join(',')})`);
+    return `${escapeName(typeName)}(${variants.join(',')})`;
+  }
+  const fields = def.map((f) => `${escapeName(f.name)}:${escapeName(f.type)}`);
+  return `${escapeName(typeName)}(${fields.join(',')})`;
+}
+
+/** encode_type(T) = encoding of T followed by the encodings of all transitively referenced user types, sorted by byte order. */
+export function encodeType(types, typeName) {
+  const all = new Set();
+  const stack = [...directDependencies(types, typeName)];
+  while (stack.length) {
+    const t = stack.pop();
+    if (t === typeName || all.has(t)) continue;
+    all.add(t);
+    stack.push(...directDependencies(types, t));
+  }
+  const deps = [...all].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)); // code-point order == byte order for ASCII names
+  return [typeName, ...deps].map((t) => encodeSingleType(types, t)).join('');
+}
+
+export function typeHash(types, typeName) {
+  return starknetKeccak(encodeType(types, typeName));
+}
+
+// ---------------------------------------------------------------------------
+// Value encoding. Every encoder returns an array of felts (length 1, or 2 for u256).
+// ---------------------------------------------------------------------------
+
+function parseInteger(value, what) {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw new Error(`${what}: number is not a safe integer`);
+    return BigInt(value);
+  }
+  if (typeof value === 'string') {
+    if (/^-?[0-9]+$/.test(value)) return BigInt(value);
+    if (/^0x[0-9a-fA-F]+$/.test(value)) return BigInt(value);
+  }
+  throw new Error(`${what}: expected an integer (JSON number, decimal string or 0x hex string), got ${JSON.stringify(value)}`);
+}
+
+function inRange(v, lo, hi, what) {
+  if (v < lo || v > hi) throw new Error(`${what}: value ${v} out of range [${lo}, ${hi}]`);
+  return v;
+}
+
+function encodeBasic(type, value, what) {
+  switch (type) {
+    case 'felt':
+      return [inRange(parseInteger(value, what), 0n, PRIME - 1n, what)];
+    case 'ContractAddress':
+    case 'ClassHash':
+      return [inRange(parseInteger(value, what), 0n, ADDRESS_BOUND - 1n, what)];
+    case 'bytes31':
+      return [inRange(parseInteger(value, what), 0n, 2n ** 248n - 1n, what)];
+    case 'bool':
+      if (typeof value !== 'boolean') throw new Error(`${what}: bool must be a JSON boolean`);
+      return [value ? 1n : 0n];
+    case 'shortstring':
+      if (typeof value !== 'string') throw new Error(`${what}: shortstring must be a JSON string`);
+      return [shortStringToFelt(value)];
+    case 'selector':
+      if (typeof value !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`${what}: selector must be a Cairo identifier`);
+      return [starknetKeccak(value)];
+    case 'string':
+      if (typeof value !== 'string') throw new Error(`${what}: string must be a JSON string`);
+      return [encodeByteArray(value)];
+    case 'u256': {
+      const v = inRange(parseInteger(value, what), 0n, 2n ** 256n - 1n, what);
+      return [v & (2n ** 128n - 1n), v >> 128n];
+    }
+    default:
+      if (type in UNSIGNED) return [inRange(parseInteger(value, what), 0n, 2n ** UNSIGNED[type] - 1n, what)];
+      if (type in SIGNED) {
+        const bits = SIGNED[type];
+        const v = inRange(parseInteger(value, what), -(2n ** (bits - 1n)), 2n ** (bits - 1n) - 1n, what);
+        return [v < 0n ? PRIME + v : v];
+      }
+      throw new Error(`${what}: not a basic type: ${type}`);
+  }
+}
+
+/** string: Cairo ByteArray serialisation of the UTF-8 bytes, hashed. */
+export function encodeByteArray(str) {
+  const bytes = new TextEncoder().encode(str);
+  const words = [];
+  let i = 0;
+  for (; i + 31 <= bytes.length; i += 31) words.push(bytesToFelt(bytes.subarray(i, i + 31)));
+  const pending = bytes.subarray(i);
+  return hashArray([BigInt(words.length), ...words, bytesToFelt(pending), BigInt(pending.length)]);
+}
+
+function bytesToFelt(bytes) {
+  let v = 0n;
+  for (const b of bytes) v = (v << 8n) | BigInt(b);
+  return v;
+}
+
+export function encodeValue(types, type, value, what, contains) {
+  const { base, depth } = stripArray(type);
+  if (depth > 0) {
+    if (!Array.isArray(value)) throw new Error(`${what}: expected an array`);
+    const inner = type.slice(0, -1);
+    const felts = value.flatMap((v, i) => encodeValue(types, inner, v, `${what}[${i}]`, contains));
+    return [hashArray(felts)];
+  }
+  if (base === 'merkletree') return [merkleRoot(types, contains, value, what)];
+  if (BASIC_TYPES.has(base)) return encodeBasic(base, value, what);
+  if (!types[base]) throw new Error(`${what}: unknown type ${base}`);
+  return [isEnumDefinition(types[base]) ? encodeEnum(types, base, value, what) : encodeStruct(types, base, value, what)];
+}
+
+export function encodeStruct(types, typeName, value, what = typeName) {
+  const def = types[typeName];
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${what}: expected an object`);
+  checkObjectKeys(value, def.map((f) => f.name), what);
+  const felts = [typeHash(types, typeName)];
+  for (const field of def) felts.push(...encodeValue(types, field.type, value[field.name], `${what}.${field.name}`, field.contains));
+  return hashArray(felts);
+}
+
+export function encodeEnum(types, typeName, value, what = typeName) {
+  const def = types[typeName];
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${what}: enum value must be an object`);
+  const keys = Object.keys(value);
+  if (keys.length !== 1) throw new Error(`${what}: enum value must have exactly one key`);
+  const [variantName] = keys;
+  const index = def.findIndex((v) => v.name === variantName);
+  if (index < 0) throw new Error(`${what}: unknown variant ${variantName}`);
+  const params = variantParams(def[index].type);
+  const args = value[variantName];
+  if (!Array.isArray(args) || args.length !== params.length) throw new Error(`${what}: variant ${variantName} expects ${params.length} parameter(s)`);
+  const felts = [typeHash(types, typeName), BigInt(index)];
+  params.forEach((p, i) => felts.push(...encodeValue(types, p, args[i], `${what}.${variantName}[${i}]`)));
+  return hashArray(felts);
+}
+
+/** merkletree: leaves are Enc[leaf]; pairs hashed commutatively with hash_array; an odd node is promoted. */
+export function merkleRoot(types, leafType, leaves, what) {
+  if (!Array.isArray(leaves) || leaves.length === 0) throw new Error(`${what}: merkletree needs at least one leaf`);
+  let level = leaves.map((leaf, i) => {
+    const enc = encodeValue(types, leafType, leaf, `${what}[${i}]`);
+    if (enc.length !== 1) throw new Error(`${what}: merkletree leaves must encode to a single felt`);
+    return enc[0];
+  });
+  while (level.length > 1) {
+    const next = [];
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 === level.length) next.push(level[i]);
+      else next.push(hashPair(level[i], level[i + 1]));
+    }
+    level = next;
+  }
+  return level[0];
+}
+
+export function hashPair(a, b) {
+  return a <= b ? hashArray([a, b]) : hashArray([b, a]);
+}
+
+// ---------------------------------------------------------------------------
+// Message hash
+// ---------------------------------------------------------------------------
+
+export function domainHash(td) {
+  return encodeStruct(td.types, DOMAIN_TYPE, td.domain, 'domain');
+}
+
+export function primaryStructHash(td) {
+  return encodeStruct(td.types, td.primaryType, td.message, 'message');
+}
+
+export function messageHash(td, account) {
+  validateTypedData(td);
+  const acc = inRange(parseInteger(account, 'account'), 0n, ADDRESS_BOUND - 1n, 'account');
+  return hashArray([shortStringToFelt(PREFIX_MESSAGE), domainHash(td), acc, primaryStructHash(td)]);
+}
+
+export function describe(td, account) {
+  validateTypedData(td);
+  const userTypes = Object.keys(td.types);
+  const encode_type = Object.fromEntries(userTypes.map((t) => [t, encodeType(td.types, t)]));
+  const type_hash = Object.fromEntries(userTypes.map((t) => [t, toHex(typeHash(td.types, t))]));
+  return {
+    encode_type,
+    type_hash,
+    domain_hash: toHex(domainHash(td)),
+    struct_hash: toHex(primaryStructHash(td)),
+    message_hash: toHex(messageHash(td, account)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const [, , cmd, ...args] = process.argv;
+if (cmd === 'hash') {
+  const td = JSON.parse(readFileSync(args[0], 'utf8'));
+  console.log(JSON.stringify(describe(td, args[1] ?? '0x1234'), null, 2));
+} else if (cmd === 'verify') {
+  const file = JSON.parse(readFileSync(args[0], 'utf8'));
+  let failures = 0;
+  for (const v of file.vectors) {
+    const got = describe(v.typed_data, file.account);
+    const exp = v.expected;
+    const same = JSON.stringify(got) === JSON.stringify(exp);
+    if (!same) { failures += 1; console.error(`MISMATCH ${v.name}\n got ${JSON.stringify(got)}\n exp ${JSON.stringify(exp)}`); }
+    else console.log(`ok       ${v.name}`);
+  }
+  for (const v of file.invalid) {
+    let threw = null;
+    try { messageHash(v.typed_data, file.account); } catch (e) { threw = e.message; }
+    if (!threw) { failures += 1; console.error(`ACCEPTED ${v.name} (should have been rejected: ${v.reason})`); }
+    else console.log(`rejected ${v.name}: ${threw}`);
+  }
+  if (failures) { console.error(`${failures} failure(s)`); process.exit(1); }
+  console.log('all vectors verified');
+} else if (cmd === 'generate') {
+  const { buildVectors } = await import('./vectors-src.mjs');
+  console.log(JSON.stringify(buildVectors(describe, messageHash), null, 2));
+}

--- a/assets/snip-12/rev2/encoder.mjs
+++ b/assets/snip-12/rev2/encoder.mjs
@@ -133,6 +133,7 @@ export function validateTypedData(td) {
 
   if (primaryType === DOMAIN_TYPE) throw new Error('primaryType cannot be the domain');
   if (!types[primaryType]) throw new Error(`unknown primaryType ${primaryType}`);
+  if (Array.isArray(types[primaryType]) && isEnumDefinition(types[primaryType])) throw new Error(`primaryType ${primaryType} must be a struct, not an enum`);
 
   // Type definitions.
   for (const [name, def] of Object.entries(types)) {
@@ -148,6 +149,7 @@ export function validateTypedData(td) {
       if (typeof field.type !== 'string' || field.type.length === 0) throw new Error(`field ${name}.${field.name} has no type`);
       const paren = field.type.startsWith('(');
       if (isEnum !== paren) throw new Error(`type ${name} mixes struct fields and enum variants`);
+      if ('contains' in field && field.type !== 'merkletree') throw new Error(`"contains" is only allowed on merkletree fields (${name}.${field.name})`);
       const refs = isEnum ? variantParams(field.type) : [field.type];
       for (const ref of refs) {
         const { base } = stripArray(ref);

--- a/assets/snip-12/rev2/package.json
+++ b/assets/snip-12/rev2/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "snip-12-rev2-vectors",
+  "private": true,
+  "type": "module",
+  "description": "Reference encoder and test vectors for SNIP-12 revision 2 (draft)",
+  "scripts": {
+    "generate": "node encoder.mjs generate > vectors.json",
+    "verify": "node encoder.mjs verify vectors.json"
+  },
+  "dependencies": {
+    "starknet": "10.7.2"
+  }
+}

--- a/assets/snip-12/rev2/vectors-src.mjs
+++ b/assets/snip-12/rev2/vectors-src.mjs
@@ -161,6 +161,20 @@ export const VALID = [
     ),
   },
   {
+    name: 'domain-descriptor-key-order',
+    description: 'Key order inside a field descriptor is not significant; this hashes identically to the same document written {name, type}.',
+    typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, DOMAIN, DOMAIN_TYPE.map(({ name, type }) => ({ type, name }))),
+  },
+  {
+    name: 'json-number-limits',
+    description: 'A JSON number may be used up to 2^53 - 1; anything larger must be a decimal or 0x string (here 2^53 in both string forms).',
+    typed_data: doc(
+      { Limits: [{ name: 'Max Number', type: 'u64' }, { name: 'Decimal String', type: 'u64' }, { name: 'Hex String', type: 'u64' }] },
+      'Limits',
+      { 'Max Number': 9007199254740991, 'Decimal String': '9007199254740992', 'Hex String': '0x20000000000000' },
+    ),
+  },
+  {
     name: 'domain-verifying-contract',
     description: 'Optional verifyingContract in the domain.',
     typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, verifyingContract: '0x0777' }, [...DOMAIN_TYPE, { name: 'verifyingContract', type: 'ContractAddress' }]),
@@ -199,6 +213,11 @@ export const INVALID = [
   { name: 'address-above-bound', reason: 'ContractAddress must be below 2^251', typed_data: doc({ T: [{ name: 'a', type: 'ContractAddress' }] }, 'T', { a: '0x800000000000000000000000000000000000000000000000000000000000000' }) },
   { name: 'selector-hex', reason: 'selector values must be entrypoint names, never hashes', typed_data: doc({ T: [{ name: 's', type: 'selector' }] }, 'T', { s: '0x1' }) },
   { name: 'selector-invalid-identifier', reason: 'selector must be a Cairo identifier', typed_data: doc({ T: [{ name: 's', type: 'selector' }] }, 'T', { s: 'trans fer' }) },
+  { name: 'json-number-above-limit', reason: 'a JSON number above 2^53 - 1 must be given as a string', typed_data: doc({ T: [{ name: 'n', type: 'u64' }] }, 'T', { n: 9007199254740992 }) },
+  { name: 'json-number-fractional', reason: 'a JSON number must be a whole number', typed_data: doc({ T: [{ name: 'n', type: 'u64' }] }, 'T', { n: 1.5 }) },
+  { name: 'string-unpaired-high-surrogate', reason: 'string values must be well-formed Unicode', typed_data: doc({ T: [{ name: 's', type: 'string' }] }, 'T', { s: 'a\ud800b' }) },
+  { name: 'string-unpaired-low-surrogate', reason: 'string values must be well-formed Unicode', typed_data: doc({ T: [{ name: 's', type: 'string' }] }, 'T', { s: 'a\udc00b' }) },
+  { name: 'field-descriptor-unknown-key', reason: 'a field descriptor may only carry name, type and (for merkletree) contains', typed_data: doc({ T: [{ name: 'n', type: 'u8', display: 'hex' }] }, 'T', { n: 1 }) },
   { name: 'shortstring-too-long', reason: 'shortstring longer than 31 bytes', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: STR32 }) },
   { name: 'shortstring-non-ascii', reason: 'shortstring must be printable ASCII', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: 'héllo' }) },
   { name: 'shortstring-as-number', reason: 'shortstring values must be JSON strings', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: 2 }) },

--- a/assets/snip-12/rev2/vectors-src.mjs
+++ b/assets/snip-12/rev2/vectors-src.mjs
@@ -152,6 +152,15 @@ export const VALID = [
     ),
   },
   {
+    name: 'single-variant-enum',
+    description: 'A type whose only field type is parenthesised is a one-variant enum, not a tuple; nested in a struct it is valid.',
+    typed_data: doc(
+      { Wrapper: [{ name: 'pair', type: 'Pair' }], Pair: [{ name: 'Values', type: '(felt,u128)' }] },
+      'Wrapper',
+      { pair: { Values: [1, 2] } },
+    ),
+  },
+  {
     name: 'domain-verifying-contract',
     description: 'Optional verifyingContract in the domain.',
     typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, verifyingContract: '0x0777' }, [...DOMAIN_TYPE, { name: 'verifyingContract', type: 'ContractAddress' }]),
@@ -195,7 +204,10 @@ export const INVALID = [
   { name: 'shortstring-as-number', reason: 'shortstring values must be JSON strings', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: 2 }) },
   { name: 'bool-as-string', reason: 'bool must be a JSON boolean', typed_data: doc({ T: [{ name: 'b', type: 'bool' }] }, 'T', { b: 'true' }) },
   { name: 'reserved-type-name', reason: 'user types cannot use a basic type name', typed_data: doc({ u256: [{ name: 'low', type: 'u128' }], T: [{ name: 'a', type: 'u256' }] }, 'T', { a: { low: 1 } }) },
-  { name: 'tuple-field-type', reason: 'tuples are not a SNIP-12 type; model them as a struct', typed_data: doc({ T: [{ name: 'n', type: '(felt,u128)' }] }, 'T', { n: [1, 2] }) },
+  { name: 'tuple-as-primary-type', reason: 'an all-parenthesised type is an enum, and primaryType must be a struct', typed_data: doc({ T: [{ name: 'n', type: '(felt,u128)' }] }, 'T', { n: [1, 2] }) },
+  { name: 'tuple-next-to-struct-field', reason: 'a type mixes struct fields and enum variants', typed_data: doc({ T: [{ name: 'n', type: '(felt,u128)' }, { name: 'm', type: 'u8' }] }, 'T', { n: [1, 2], m: 1 }) },
+  { name: 'enum-as-primary-type', reason: 'primaryType must be a struct', typed_data: doc(enumTypes, 'Fee Mode', { 'No Fee': [] }) },
+  { name: 'contains-on-non-merkletree', reason: '"contains" is only allowed on merkletree fields', typed_data: doc({ P: [{ name: 'n', type: 'u8', contains: 'NoSuchType' }] }, 'P', { n: 1 }) },
   { name: 'duplicate-field-name', reason: 'field names within a type must be unique', typed_data: doc({ T: [{ name: 'a', type: 'u8' }, { name: 'a', type: 'u8' }] }, 'T', { a: 1 }) },
   { name: 'name-with-quote', reason: 'names cannot contain the double quote character', typed_data: doc({ T: [{ name: 'a"b', type: 'u8' }] }, 'T', { 'a"b': 1 }) },
   { name: 'name-with-colon', reason: 'names cannot contain the colon character', typed_data: doc({ T: [{ name: 'a:b', type: 'u8' }] }, 'T', { 'a:b': 1 }) },

--- a/assets/snip-12/rev2/vectors-src.mjs
+++ b/assets/snip-12/rev2/vectors-src.mjs
@@ -1,0 +1,236 @@
+// Source of the SNIP-12 revision 2 test vectors. `node encoder.mjs generate` turns this into vectors.json.
+
+const ACCOUNT = '0x1234';
+
+const DOMAIN_TYPE = [
+  { name: 'name', type: 'shortstring' },
+  { name: 'version', type: 'shortstring' },
+  { name: 'chainId', type: 'shortstring' },
+  { name: 'revision', type: 'shortstring' },
+];
+const DOMAIN = { name: 'SNIP-12 Rev 2 Vectors', version: '1', chainId: 'SN_SEPOLIA', revision: '2' };
+
+const doc = (types, primaryType, message, domain = DOMAIN, domainType = DOMAIN_TYPE) => ({
+  types: { StarknetDomain: domainType, ...types },
+  primaryType,
+  domain,
+  message,
+});
+
+const U128_MAX = '340282366920938463463374607431768211455';
+const U256_MAX = '115792089237316195423570985008687907853269984665640564039457584007913129639935';
+const STR31 = 'abcdefghijklmnopqrstuvwxyz01234'; // 31 bytes
+const STR32 = STR31 + '5'; // 32 bytes
+
+const merkleTypes = {
+  Session: [
+    { name: 'Expires At', type: 'timestamp' },
+    { name: 'Allowed Methods', type: 'merkletree', contains: 'Allowed Method' },
+  ],
+  'Allowed Method': [
+    { name: 'Contract Address', type: 'ContractAddress' },
+    { name: 'Selector', type: 'selector' },
+  ],
+};
+const leaf = (addr, sel) => ({ 'Contract Address': addr, Selector: sel });
+const leaves = [leaf('0x1', 'transfer'), leaf('0x2', 'approve'), leaf('0x3', 'mint'), leaf('0x4', 'burn'), leaf('0x5', 'swap')];
+
+const enumTypes = {
+  Payment: [
+    { name: 'Payer', type: 'ContractAddress' },
+    { name: 'Fee', type: 'Fee Mode' },
+  ],
+  'Fee Mode': [
+    { name: 'No Fee', type: '()' },
+    { name: 'Pay Fee', type: '(Fee Transfer)' },
+    { name: 'Split', type: '(u128,u128*)' },
+  ],
+  'Fee Transfer': [
+    { name: 'Fee Amount', type: 'TokenAmount' },
+    { name: 'Fee Receiver', type: 'ContractAddress' },
+  ],
+  TokenAmount: [
+    { name: 'token_address', type: 'ContractAddress' },
+    { name: 'amount', type: 'u256' },
+  ],
+};
+
+export const VALID = [
+  {
+    name: 'integers',
+    description: 'Every integer basic type, including negative signed values (encoded as P + v) and timestamp (u64).',
+    typed_data: doc(
+      { Integers: [
+        { name: 'a', type: 'u8' }, { name: 'b', type: 'u16' }, { name: 'c', type: 'u32' }, { name: 'd', type: 'u64' }, { name: 'e', type: 'u128' },
+        { name: 'f', type: 'i8' }, { name: 'g', type: 'i16' }, { name: 'h', type: 'i32' }, { name: 'i', type: 'i64' }, { name: 'j', type: 'i128' },
+        { name: 'k', type: 'timestamp' },
+      ] },
+      'Integers',
+      { a: 255, b: 65535, c: '4294967295', d: '0xffffffffffffffff', e: U128_MAX, f: -128, g: '-1', h: 0, i: '-9223372036854775808', j: -1000, k: 1700000000 },
+    ),
+  },
+  {
+    name: 'felts-and-bool',
+    description: 'felt, ContractAddress, ClassHash, bytes31 accept JSON numbers, decimal strings and 0x strings; bool is a JSON boolean.',
+    typed_data: doc(
+      { Felts: [
+        { name: 'Felt Hex', type: 'felt' }, { name: 'Felt Dec', type: 'felt' }, { name: 'Felt Num', type: 'felt' },
+        { name: 'Address', type: 'ContractAddress' }, { name: 'Class', type: 'ClassHash' }, { name: 'Bytes', type: 'bytes31' },
+        { name: 'Yes', type: 'bool' }, { name: 'No', type: 'bool' },
+      ] },
+      'Felts',
+      { 'Felt Hex': '0x1234', 'Felt Dec': '1000', 'Felt Num': 42, Address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7', Class: '0x01', Bytes: '0x00ff', Yes: true, No: false },
+    ),
+  },
+  {
+    name: 'strings',
+    description: 'shortstring is always the ASCII bytes ("2" encodes as 0x32); string is the Cairo ByteArray serialisation of the UTF-8 bytes, hashed.',
+    typed_data: doc(
+      { Strings: [
+        { name: 'Short', type: 'shortstring' }, { name: 'Numeric Short', type: 'shortstring' }, { name: 'Empty Short', type: 'shortstring' },
+        { name: 'Empty', type: 'string' }, { name: 'Hello', type: 'string' }, { name: 'Exactly 31', type: 'string' }, { name: 'Exactly 32', type: 'string' }, { name: 'Unicode', type: 'string' },
+      ] },
+      'Strings',
+      { Short: 'hello', 'Numeric Short': '2', 'Empty Short': '', Empty: '', Hello: 'hello', 'Exactly 31': STR31, 'Exactly 32': STR32, Unicode: 'héllo wörld ✓' },
+    ),
+  },
+  {
+    name: 'selector',
+    description: 'selector is always starknet_keccak of the entrypoint name.',
+    typed_data: doc({ Call: [{ name: 'Selector', type: 'selector' }] }, 'Call', { Selector: 'transfer' }),
+  },
+  {
+    name: 'u256',
+    description: 'u256 is a basic type encoded as two felts (low, high) inside the parent hash input; the type string is just "u256".',
+    typed_data: doc(
+      { Amounts: [{ name: 'Small', type: 'u256' }, { name: 'Max', type: 'u256' }, { name: 'High Limb', type: 'u256' }, { name: 'List', type: 'u256*' }] },
+      'Amounts',
+      { Small: 1000, Max: U256_MAX, 'High Limb': '0x100000000000000000000000000000005', List: [1, '0x100000000000000000000000000000000', U256_MAX] },
+    ),
+  },
+  {
+    name: 'nested-structs-and-arrays',
+    description: 'Struct references, arrays of structs, arrays of basic types, nested arrays and an empty array.',
+    typed_data: doc(
+      {
+        Order: [{ name: 'Maker', type: 'ContractAddress' }, { name: 'Items', type: 'Item*' }, { name: 'Tags', type: 'shortstring*' }, { name: 'Matrix', type: 'u8**' }],
+        Item: [{ name: 'Token', type: 'ContractAddress' }, { name: 'Amount', type: 'u256' }],
+      },
+      'Order',
+      { Maker: '0xabc', Items: [{ Token: '0x1', Amount: 1 }, { Token: '0x2', Amount: U256_MAX }], Tags: [], Matrix: [[1, 2], [3], []] },
+    ),
+  },
+  {
+    name: 'enum-empty-variant',
+    description: 'Enum referenced by name; variant with no parameters hashes as [type_hash, index].',
+    typed_data: doc(enumTypes, 'Payment', { Payer: '0x1', Fee: { 'No Fee': [] } }),
+  },
+  {
+    name: 'enum-struct-variant',
+    description: 'Variant carrying a struct that itself contains u256 (flattened) and a nested struct dependency.',
+    typed_data: doc(enumTypes, 'Payment', { Payer: '0x1', Fee: { 'Pay Fee': [{ 'Fee Amount': { token_address: '0x4', amount: '0x100000000000000000000000000000001' }, 'Fee Receiver': '0x5' }] } }),
+  },
+  {
+    name: 'enum-tuple-variant',
+    description: 'Variant with several parameters including an array.',
+    typed_data: doc(enumTypes, 'Payment', { Payer: '0x1', Fee: { Split: [7, [1, 2, 3]] } }),
+  },
+  { name: 'merkletree-1-leaf', description: 'A single leaf is the root.', typed_data: doc(merkleTypes, 'Session', { 'Expires At': 1700000000, 'Allowed Methods': leaves.slice(0, 1) }) },
+  { name: 'merkletree-2-leaves', description: 'Pair hashed commutatively with hash_array.', typed_data: doc(merkleTypes, 'Session', { 'Expires At': 1700000000, 'Allowed Methods': leaves.slice(0, 2) }) },
+  { name: 'merkletree-3-leaves', description: 'Odd node is promoted unchanged.', typed_data: doc(merkleTypes, 'Session', { 'Expires At': 1700000000, 'Allowed Methods': leaves.slice(0, 3) }) },
+  { name: 'merkletree-5-leaves', description: 'Two levels with promotion.', typed_data: doc(merkleTypes, 'Session', { 'Expires At': 1700000000, 'Allowed Methods': leaves }) },
+  {
+    name: 'merkletree-of-enums',
+    description: 'Leaves may be enums.',
+    typed_data: doc(
+      {
+        Policy: [{ name: 'Rules', type: 'merkletree', contains: 'Rule' }],
+        Rule: [{ name: 'Allow', type: '(ContractAddress)' }, { name: 'Deny All', type: '()' }],
+      },
+      'Policy',
+      { Rules: [{ Allow: ['0x1'] }, { 'Deny All': [] }, { Allow: ['0x2'] }] },
+    ),
+  },
+  {
+    name: 'domain-verifying-contract',
+    description: 'Optional verifyingContract in the domain.',
+    typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, verifyingContract: '0x0777' }, [...DOMAIN_TYPE, { name: 'verifyingContract', type: 'ContractAddress' }]),
+  },
+  {
+    name: 'domain-salt',
+    description: 'Optional salt in the domain.',
+    typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, salt: '0x5a17' }, [...DOMAIN_TYPE, { name: 'salt', type: 'felt' }]),
+  },
+  {
+    name: 'domain-verifying-contract-and-salt',
+    description: 'Both optional domain fields, in the required order.',
+    typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, verifyingContract: '0x0777', salt: '0x5a17' }, [...DOMAIN_TYPE, { name: 'verifyingContract', type: 'ContractAddress' }, { name: 'salt', type: 'felt' }]),
+  },
+];
+
+const ping = (over = {}) => doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, ...over });
+
+export const INVALID = [
+  { name: 'revision-as-number', reason: 'revision must be the JSON string "2"', typed_data: ping({ revision: 2 }) },
+  { name: 'revision-1-document', reason: 'a revision 1 document is not a revision 2 document', typed_data: ping({ revision: '1' }) },
+  { name: 'domain-extra-field', reason: 'domain object has a field the domain type does not declare', typed_data: ping({ extra: 1 }) },
+  { name: 'domain-chain_id-key', reason: 'legacy chain_id key', typed_data: (() => { const d = ping(); delete d.domain.chainId; d.domain.chain_id = 'SN_SEPOLIA'; return d; })() },
+  { name: 'domain-fields-reordered', reason: 'domain type fields must be in the specified order', typed_data: (() => { const d = ping(); d.types.StarknetDomain = [DOMAIN_TYPE[0], DOMAIN_TYPE[2], DOMAIN_TYPE[1], DOMAIN_TYPE[3]]; return d; })() },
+  { name: 'domain-optional-out-of-order', reason: 'salt must come after verifyingContract', typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }] }, 'Ping', { n: 1 }, { ...DOMAIN, salt: '0x1', verifyingContract: '0x2' }, [...DOMAIN_TYPE, { name: 'salt', type: 'felt' }, { name: 'verifyingContract', type: 'ContractAddress' }]) },
+  { name: 'primary-type-is-domain', reason: 'primaryType cannot be StarknetDomain', typed_data: (() => { const d = ping(); d.primaryType = 'StarknetDomain'; d.message = d.domain; return d; })() },
+  { name: 'unknown-type', reason: 'field type is neither basic nor declared', typed_data: doc({ Ping: [{ name: 'n', type: 'uint256' }] }, 'Ping', { n: 1 }) },
+  { name: 'dangling-type', reason: 'declared type not reachable from primaryType', typed_data: doc({ Ping: [{ name: 'n', type: 'u8' }], Unused: [{ name: 'x', type: 'u8' }] }, 'Ping', { n: 1 }) },
+  { name: 'recursive-type', reason: 'recursive type definitions are not allowed', typed_data: doc({ Node: [{ name: 'children', type: 'Node*' }] }, 'Node', { children: [] }) },
+  { name: 'message-undeclared-field', reason: 'message has a field the type does not declare', typed_data: (() => { const d = ping(); d.message.extra = 2; return d; })() },
+  { name: 'message-missing-field', reason: 'message lacks a declared field', typed_data: (() => { const d = ping(); d.message = {}; return d; })() },
+  { name: 'u8-out-of-range', reason: 'value exceeds the type range', typed_data: (() => { const d = ping(); d.message.n = 256; return d; })() },
+  { name: 'u64-negative', reason: 'unsigned type given a negative value', typed_data: doc({ T: [{ name: 'n', type: 'u64' }] }, 'T', { n: -1 }) },
+  { name: 'i8-out-of-range', reason: 'signed value below the type range', typed_data: doc({ T: [{ name: 'n', type: 'i8' }] }, 'T', { n: -129 }) },
+  { name: 'felt-at-prime', reason: 'felt must be below the field prime', typed_data: doc({ T: [{ name: 'n', type: 'felt' }] }, 'T', { n: '0x800000000000011000000000000000000000000000000000000000000000001' }) },
+  { name: 'address-above-bound', reason: 'ContractAddress must be below 2^251', typed_data: doc({ T: [{ name: 'a', type: 'ContractAddress' }] }, 'T', { a: '0x800000000000000000000000000000000000000000000000000000000000000' }) },
+  { name: 'selector-hex', reason: 'selector values must be entrypoint names, never hashes', typed_data: doc({ T: [{ name: 's', type: 'selector' }] }, 'T', { s: '0x1' }) },
+  { name: 'selector-invalid-identifier', reason: 'selector must be a Cairo identifier', typed_data: doc({ T: [{ name: 's', type: 'selector' }] }, 'T', { s: 'trans fer' }) },
+  { name: 'shortstring-too-long', reason: 'shortstring longer than 31 bytes', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: STR32 }) },
+  { name: 'shortstring-non-ascii', reason: 'shortstring must be printable ASCII', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: 'héllo' }) },
+  { name: 'shortstring-as-number', reason: 'shortstring values must be JSON strings', typed_data: doc({ T: [{ name: 's', type: 'shortstring' }] }, 'T', { s: 2 }) },
+  { name: 'bool-as-string', reason: 'bool must be a JSON boolean', typed_data: doc({ T: [{ name: 'b', type: 'bool' }] }, 'T', { b: 'true' }) },
+  { name: 'reserved-type-name', reason: 'user types cannot use a basic type name', typed_data: doc({ u256: [{ name: 'low', type: 'u128' }], T: [{ name: 'a', type: 'u256' }] }, 'T', { a: { low: 1 } }) },
+  { name: 'tuple-field-type', reason: 'tuples are not a SNIP-12 type; model them as a struct', typed_data: doc({ T: [{ name: 'n', type: '(felt,u128)' }] }, 'T', { n: [1, 2] }) },
+  { name: 'duplicate-field-name', reason: 'field names within a type must be unique', typed_data: doc({ T: [{ name: 'a', type: 'u8' }, { name: 'a', type: 'u8' }] }, 'T', { a: 1 }) },
+  { name: 'name-with-quote', reason: 'names cannot contain the double quote character', typed_data: doc({ T: [{ name: 'a"b', type: 'u8' }] }, 'T', { 'a"b': 1 }) },
+  { name: 'name-with-colon', reason: 'names cannot contain the colon character', typed_data: doc({ T: [{ name: 'a:b', type: 'u8' }] }, 'T', { 'a:b': 1 }) },
+  { name: 'name-trailing-space', reason: 'names cannot start or end with whitespace', typed_data: doc({ T: [{ name: 'a ', type: 'u8' }] }, 'T', { 'a ': 1 }) },
+  { name: 'type-name-with-star', reason: 'type names cannot end with *', typed_data: doc({ 'T*': [{ name: 'a', type: 'u8' }] }, 'T*', { a: 1 }) },
+  { name: 'enum-two-keys', reason: 'an enum value has exactly one variant key', typed_data: doc(enumTypes, 'Payment', { Payer: '0x1', Fee: { 'No Fee': [], Split: [1, []] } }) },
+  { name: 'enum-unknown-variant', reason: 'variant not declared', typed_data: doc(enumTypes, 'Payment', { Payer: '0x1', Fee: { Free: [] } }) },
+  { name: 'enum-param-count', reason: 'variant parameters must match the declaration', typed_data: doc(enumTypes, 'Payment', { Payer: '0x1', Fee: { Split: [1] } }) },
+  { name: 'enum-with-contains', reason: 'revision 2 references enums by name; the "enum" pseudo-type is gone', typed_data: doc({ ...enumTypes, Payment: [{ name: 'Payer', type: 'ContractAddress' }, { name: 'Fee', type: 'enum', contains: 'Fee Mode' }] }, 'Payment', { Payer: '0x1', Fee: { 'No Fee': [] } }) },
+  { name: 'merkletree-missing-contains', reason: 'merkletree fields must name their leaf type', typed_data: doc({ T: [{ name: 'm', type: 'merkletree' }], L: [{ name: 'x', type: 'u8' }] }, 'T', { m: [{ x: 1 }] }) },
+  { name: 'merkletree-empty', reason: 'a merkletree must have at least one leaf', typed_data: doc(merkleTypes, 'Session', { 'Expires At': 1, 'Allowed Methods': [] }) },
+  { name: 'merkletree-basic-leaf', reason: 'leaves must be user-defined structs or enums', typed_data: doc({ T: [{ name: 'm', type: 'merkletree', contains: 'u8' }] }, 'T', { m: [1, 2] }) },
+  { name: 'array-given-scalar', reason: 'array-typed field given a scalar', typed_data: doc({ T: [{ name: 'a', type: 'u8*' }] }, 'T', { a: 1 }) },
+  { name: 'struct-given-array', reason: 'struct-typed field given an array', typed_data: doc({ T: [{ name: 'i', type: 'Item' }], Item: [{ name: 'x', type: 'u8' }] }, 'T', { i: [1] }) },
+];
+
+export function buildVectors(describe, messageHash) {
+  const vectors = VALID.map((v) => ({ ...v, expected: describe(v.typed_data, ACCOUNT) }));
+  for (const v of INVALID) {
+    let threw = false;
+    try { messageHash(v.typed_data, ACCOUNT); } catch { threw = true; }
+    if (!threw) throw new Error(`invalid vector was accepted: ${v.name}`);
+  }
+  return {
+    snip: 12,
+    revision: '2',
+    status: 'draft',
+    generated_by: 'assets/snip-12/rev2/encoder.mjs',
+    account: ACCOUNT,
+    notes: [
+      'message_hash = hash_array(["StarkNet Message", domain_hash, account, struct_hash]) with hash_array = Poseidon (poseidon_hash_span).',
+      'All hex values are 0x-prefixed field elements without zero padding.',
+      'Every document under "invalid" MUST be rejected by a conforming implementation; "reason" names the rule.',
+    ],
+    vectors,
+    invalid: INVALID,
+  };
+}

--- a/assets/snip-12/rev2/vectors.json
+++ b/assets/snip-12/rev2/vectors.json
@@ -1,0 +1,3339 @@
+{
+  "snip": 12,
+  "revision": "2",
+  "status": "draft",
+  "generated_by": "assets/snip-12/rev2/encoder.mjs",
+  "account": "0x1234",
+  "notes": [
+    "message_hash = hash_array([\"StarkNet Message\", domain_hash, account, struct_hash]) with hash_array = Poseidon (poseidon_hash_span).",
+    "All hex values are 0x-prefixed field elements without zero padding.",
+    "Every document under \"invalid\" MUST be rejected by a conforming implementation; \"reason\" names the rule."
+  ],
+  "vectors": [
+    {
+      "name": "integers",
+      "description": "Every integer basic type, including negative signed values (encoded as P + v) and timestamp (u64).",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Integers": [
+            {
+              "name": "a",
+              "type": "u8"
+            },
+            {
+              "name": "b",
+              "type": "u16"
+            },
+            {
+              "name": "c",
+              "type": "u32"
+            },
+            {
+              "name": "d",
+              "type": "u64"
+            },
+            {
+              "name": "e",
+              "type": "u128"
+            },
+            {
+              "name": "f",
+              "type": "i8"
+            },
+            {
+              "name": "g",
+              "type": "i16"
+            },
+            {
+              "name": "h",
+              "type": "i32"
+            },
+            {
+              "name": "i",
+              "type": "i64"
+            },
+            {
+              "name": "j",
+              "type": "i128"
+            },
+            {
+              "name": "k",
+              "type": "timestamp"
+            }
+          ]
+        },
+        "primaryType": "Integers",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a": 255,
+          "b": 65535,
+          "c": "4294967295",
+          "d": "0xffffffffffffffff",
+          "e": "340282366920938463463374607431768211455",
+          "f": -128,
+          "g": "-1",
+          "h": 0,
+          "i": "-9223372036854775808",
+          "j": -1000,
+          "k": 1700000000
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Integers": "\"Integers\"(\"a\":\"u8\",\"b\":\"u16\",\"c\":\"u32\",\"d\":\"u64\",\"e\":\"u128\",\"f\":\"i8\",\"g\":\"i16\",\"h\":\"i32\",\"i\":\"i64\",\"j\":\"i128\",\"k\":\"timestamp\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Integers": "0x2ac6b645845e85e8a61850effdb35fcd29377c12e9704f2ae61decba9f57810"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x4e550e8e31492f2e892e1f13562ac35b7ac5eaff43fa5c24ba7429e7c7f19ac",
+        "message_hash": "0x578f1e1b36755180f636119ec7ac64ac41d73efdc65ed976e6cb6aadc2bf1ca"
+      }
+    },
+    {
+      "name": "felts-and-bool",
+      "description": "felt, ContractAddress, ClassHash, bytes31 accept JSON numbers, decimal strings and 0x strings; bool is a JSON boolean.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Felts": [
+            {
+              "name": "Felt Hex",
+              "type": "felt"
+            },
+            {
+              "name": "Felt Dec",
+              "type": "felt"
+            },
+            {
+              "name": "Felt Num",
+              "type": "felt"
+            },
+            {
+              "name": "Address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Class",
+              "type": "ClassHash"
+            },
+            {
+              "name": "Bytes",
+              "type": "bytes31"
+            },
+            {
+              "name": "Yes",
+              "type": "bool"
+            },
+            {
+              "name": "No",
+              "type": "bool"
+            }
+          ]
+        },
+        "primaryType": "Felts",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Felt Hex": "0x1234",
+          "Felt Dec": "1000",
+          "Felt Num": 42,
+          "Address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+          "Class": "0x01",
+          "Bytes": "0x00ff",
+          "Yes": true,
+          "No": false
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Felts": "\"Felts\"(\"Felt Hex\":\"felt\",\"Felt Dec\":\"felt\",\"Felt Num\":\"felt\",\"Address\":\"ContractAddress\",\"Class\":\"ClassHash\",\"Bytes\":\"bytes31\",\"Yes\":\"bool\",\"No\":\"bool\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Felts": "0x646cf518dce2679580b809be734e33134dc0dbd9dea5a7158f212dca571e6"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x1b3f0fd5e3e3962080c9859666d63d8dfc4ed25f344b2819980c48977502402",
+        "message_hash": "0x1d96ab81bbd92237ff92e0203581253aa70dbe8b30157ffbd871478fc20b8a0"
+      }
+    },
+    {
+      "name": "strings",
+      "description": "shortstring is always the ASCII bytes (\"2\" encodes as 0x32); string is the Cairo ByteArray serialisation of the UTF-8 bytes, hashed.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Strings": [
+            {
+              "name": "Short",
+              "type": "shortstring"
+            },
+            {
+              "name": "Numeric Short",
+              "type": "shortstring"
+            },
+            {
+              "name": "Empty Short",
+              "type": "shortstring"
+            },
+            {
+              "name": "Empty",
+              "type": "string"
+            },
+            {
+              "name": "Hello",
+              "type": "string"
+            },
+            {
+              "name": "Exactly 31",
+              "type": "string"
+            },
+            {
+              "name": "Exactly 32",
+              "type": "string"
+            },
+            {
+              "name": "Unicode",
+              "type": "string"
+            }
+          ]
+        },
+        "primaryType": "Strings",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Short": "hello",
+          "Numeric Short": "2",
+          "Empty Short": "",
+          "Empty": "",
+          "Hello": "hello",
+          "Exactly 31": "abcdefghijklmnopqrstuvwxyz01234",
+          "Exactly 32": "abcdefghijklmnopqrstuvwxyz012345",
+          "Unicode": "héllo wörld ✓"
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Strings": "\"Strings\"(\"Short\":\"shortstring\",\"Numeric Short\":\"shortstring\",\"Empty Short\":\"shortstring\",\"Empty\":\"string\",\"Hello\":\"string\",\"Exactly 31\":\"string\",\"Exactly 32\":\"string\",\"Unicode\":\"string\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Strings": "0x14f06ce4603119b7cbb8ae2061ec3fcc8686058dcd356a949d98ae9fe7cfab9"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x4d6176212b2d70e312f86ab9d84ea75d62cfbe437b385a55e052d284df35633",
+        "message_hash": "0x6cdd347ff2f8169e171f4da7e6c8d7534b8f8f4c21c54d4ce92cfba4edc646b"
+      }
+    },
+    {
+      "name": "selector",
+      "description": "selector is always starknet_keccak of the entrypoint name.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Call": [
+            {
+              "name": "Selector",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "Call",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Selector": "transfer"
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Call": "\"Call\"(\"Selector\":\"selector\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Call": "0x5a36952a3e9e600c0806abea4884ce4422c9656de06cbd4b23873d63227516"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0xc975f56dfd5a5849bacff9cf89bc1d075c758d62a55700d24d8a275c618018",
+        "message_hash": "0x8dcedd755607c74e8d880564dd6e637b704362023cfcbe4847ffe05e3773b2"
+      }
+    },
+    {
+      "name": "u256",
+      "description": "u256 is a basic type encoded as two felts (low, high) inside the parent hash input; the type string is just \"u256\".",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Amounts": [
+            {
+              "name": "Small",
+              "type": "u256"
+            },
+            {
+              "name": "Max",
+              "type": "u256"
+            },
+            {
+              "name": "High Limb",
+              "type": "u256"
+            },
+            {
+              "name": "List",
+              "type": "u256*"
+            }
+          ]
+        },
+        "primaryType": "Amounts",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Small": 1000,
+          "Max": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "High Limb": "0x100000000000000000000000000000005",
+          "List": [
+            1,
+            "0x100000000000000000000000000000000",
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Amounts": "\"Amounts\"(\"Small\":\"u256\",\"Max\":\"u256\",\"High Limb\":\"u256\",\"List\":\"u256*\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Amounts": "0x200fa4905d4db1374a4b4a655a69a3732276b0c6d2001ff94982ee0f3977b6e"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x2ffed8a4e4a468401e32e7b6eb2b9d9509ac08c801862507345a4e9caf645df",
+        "message_hash": "0x13bfb0d54a5b50474dcfd8c293bcb22121807a989ecb15c19eadf6a1f8701d7"
+      }
+    },
+    {
+      "name": "nested-structs-and-arrays",
+      "description": "Struct references, arrays of structs, arrays of basic types, nested arrays and an empty array.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Order": [
+            {
+              "name": "Maker",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Items",
+              "type": "Item*"
+            },
+            {
+              "name": "Tags",
+              "type": "shortstring*"
+            },
+            {
+              "name": "Matrix",
+              "type": "u8**"
+            }
+          ],
+          "Item": [
+            {
+              "name": "Token",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Order",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Maker": "0xabc",
+          "Items": [
+            {
+              "Token": "0x1",
+              "Amount": 1
+            },
+            {
+              "Token": "0x2",
+              "Amount": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+            }
+          ],
+          "Tags": [],
+          "Matrix": [
+            [
+              1,
+              2
+            ],
+            [
+              3
+            ],
+            []
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Order": "\"Order\"(\"Maker\":\"ContractAddress\",\"Items\":\"Item*\",\"Tags\":\"shortstring*\",\"Matrix\":\"u8**\")\"Item\"(\"Token\":\"ContractAddress\",\"Amount\":\"u256\")",
+          "Item": "\"Item\"(\"Token\":\"ContractAddress\",\"Amount\":\"u256\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Order": "0x2377c29745dc7ebf98d2c791e0f76965f463b1ec74276487bcb628f38896a7b",
+          "Item": "0x2f652f762e55c7e9f2fd14b50eb1c166be46fa7f9a003bf9cd60b1fe01bdd65"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x269216d666edf08040c453e497ee4f3616c643f00c13d62d0997b89880bd364",
+        "message_hash": "0x493b922654e907ff46a3bdc72faff513918998fbaa0204705bce0223b8982b1"
+      }
+    },
+    {
+      "name": "enum-empty-variant",
+      "description": "Enum referenced by name; variant with no parameters hashes as [type_hash, index].",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "No Fee": []
+          }
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Payment": "\"Payment\"(\"Payer\":\"ContractAddress\",\"Fee\":\"Fee Mode\")\"Fee Mode\"(\"No Fee\"(),\"Pay Fee\"(\"Fee Transfer\"),\"Split\"(\"u128\",\"u128*\"))\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "Fee Mode": "\"Fee Mode\"(\"No Fee\"(),\"Pay Fee\"(\"Fee Transfer\"),\"Split\"(\"u128\",\"u128*\"))\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "Fee Transfer": "\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "TokenAmount": "\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Payment": "0x110e79cd0b5e735bfeb0364241391ba2ad64e67779e60d65d206377c7d4bc6",
+          "Fee Mode": "0xb9f8f1defc578db48737cf11a215b3a9695a616b194fd4ea071bb991c6ae12",
+          "Fee Transfer": "0x1ca3374ec8b70082db753b9237530358795a804e09f33e445e7d1ca2e70d24f",
+          "TokenAmount": "0x29e9297c256ee019456057f798cbc3255f49d2cc76a1cba85e43bb71165b4a2"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x2ccedcb874b864b8e79f629b5fbe77573e0962f8e11f75c6505fd6e647b98b3",
+        "message_hash": "0x35bb2d71d04d4567964cef18f03f8c275b5673ccdeba71abeb0595403d3bd9e"
+      }
+    },
+    {
+      "name": "enum-struct-variant",
+      "description": "Variant carrying a struct that itself contains u256 (flattened) and a nested struct dependency.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "Pay Fee": [
+              {
+                "Fee Amount": {
+                  "token_address": "0x4",
+                  "amount": "0x100000000000000000000000000000001"
+                },
+                "Fee Receiver": "0x5"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Payment": "\"Payment\"(\"Payer\":\"ContractAddress\",\"Fee\":\"Fee Mode\")\"Fee Mode\"(\"No Fee\"(),\"Pay Fee\"(\"Fee Transfer\"),\"Split\"(\"u128\",\"u128*\"))\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "Fee Mode": "\"Fee Mode\"(\"No Fee\"(),\"Pay Fee\"(\"Fee Transfer\"),\"Split\"(\"u128\",\"u128*\"))\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "Fee Transfer": "\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "TokenAmount": "\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Payment": "0x110e79cd0b5e735bfeb0364241391ba2ad64e67779e60d65d206377c7d4bc6",
+          "Fee Mode": "0xb9f8f1defc578db48737cf11a215b3a9695a616b194fd4ea071bb991c6ae12",
+          "Fee Transfer": "0x1ca3374ec8b70082db753b9237530358795a804e09f33e445e7d1ca2e70d24f",
+          "TokenAmount": "0x29e9297c256ee019456057f798cbc3255f49d2cc76a1cba85e43bb71165b4a2"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x3a30bcd19c4ed9123bf11a6cd07a937fd660c88f90be0fb9aafed3ab800eecd",
+        "message_hash": "0x3ff4ef990612ded4238b8d81e6dcab4f7d88611f1e91616b2cf7629d59ab3fa"
+      }
+    },
+    {
+      "name": "enum-tuple-variant",
+      "description": "Variant with several parameters including an array.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "Split": [
+              7,
+              [
+                1,
+                2,
+                3
+              ]
+            ]
+          }
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Payment": "\"Payment\"(\"Payer\":\"ContractAddress\",\"Fee\":\"Fee Mode\")\"Fee Mode\"(\"No Fee\"(),\"Pay Fee\"(\"Fee Transfer\"),\"Split\"(\"u128\",\"u128*\"))\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "Fee Mode": "\"Fee Mode\"(\"No Fee\"(),\"Pay Fee\"(\"Fee Transfer\"),\"Split\"(\"u128\",\"u128*\"))\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "Fee Transfer": "\"Fee Transfer\"(\"Fee Amount\":\"TokenAmount\",\"Fee Receiver\":\"ContractAddress\")\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")",
+          "TokenAmount": "\"TokenAmount\"(\"token_address\":\"ContractAddress\",\"amount\":\"u256\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Payment": "0x110e79cd0b5e735bfeb0364241391ba2ad64e67779e60d65d206377c7d4bc6",
+          "Fee Mode": "0xb9f8f1defc578db48737cf11a215b3a9695a616b194fd4ea071bb991c6ae12",
+          "Fee Transfer": "0x1ca3374ec8b70082db753b9237530358795a804e09f33e445e7d1ca2e70d24f",
+          "TokenAmount": "0x29e9297c256ee019456057f798cbc3255f49d2cc76a1cba85e43bb71165b4a2"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x5c3ce62416c7568dd6e4caaa3ae686e08bc1d59df2a7facb610422ea6192887",
+        "message_hash": "0x2e55adbe09feeeb38ec317950025df961064dd49ef4fd2cf108dd7e0471c3aa"
+      }
+    },
+    {
+      "name": "merkletree-1-leaf",
+      "description": "A single leaf is the root.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Session": [
+            {
+              "name": "Expires At",
+              "type": "timestamp"
+            },
+            {
+              "name": "Allowed Methods",
+              "type": "merkletree",
+              "contains": "Allowed Method"
+            }
+          ],
+          "Allowed Method": [
+            {
+              "name": "Contract Address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Selector",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "Session",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Expires At": 1700000000,
+          "Allowed Methods": [
+            {
+              "Contract Address": "0x1",
+              "Selector": "transfer"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Session": "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\")\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")",
+          "Allowed Method": "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Session": "0x1c596d7455b21f95e0226344b87710b9583baf63b793be8cd2530d2464bbab6",
+          "Allowed Method": "0x349e733d483ab6810e692f381677b7ea1e37a3d2972c55b3f91e01ea8ec4a35"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x779e0e516d3f18139a5ade6e336a1beafe6509100e88ee8f878c6e4a6815209",
+        "message_hash": "0x8f7b252a7a75fb8fd467869a3cb6e401c0854ff7473bbad97acbc6dadbc0a9"
+      }
+    },
+    {
+      "name": "merkletree-2-leaves",
+      "description": "Pair hashed commutatively with hash_array.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Session": [
+            {
+              "name": "Expires At",
+              "type": "timestamp"
+            },
+            {
+              "name": "Allowed Methods",
+              "type": "merkletree",
+              "contains": "Allowed Method"
+            }
+          ],
+          "Allowed Method": [
+            {
+              "name": "Contract Address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Selector",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "Session",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Expires At": 1700000000,
+          "Allowed Methods": [
+            {
+              "Contract Address": "0x1",
+              "Selector": "transfer"
+            },
+            {
+              "Contract Address": "0x2",
+              "Selector": "approve"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Session": "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\")\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")",
+          "Allowed Method": "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Session": "0x1c596d7455b21f95e0226344b87710b9583baf63b793be8cd2530d2464bbab6",
+          "Allowed Method": "0x349e733d483ab6810e692f381677b7ea1e37a3d2972c55b3f91e01ea8ec4a35"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x6c67e55e6d97dc0585399ff983f90744039fab56f82650622911411a8e73525",
+        "message_hash": "0x27658caafd1df8e706ce419e0d081ec3634f25624774d3be9b0af78266af29e"
+      }
+    },
+    {
+      "name": "merkletree-3-leaves",
+      "description": "Odd node is promoted unchanged.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Session": [
+            {
+              "name": "Expires At",
+              "type": "timestamp"
+            },
+            {
+              "name": "Allowed Methods",
+              "type": "merkletree",
+              "contains": "Allowed Method"
+            }
+          ],
+          "Allowed Method": [
+            {
+              "name": "Contract Address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Selector",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "Session",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Expires At": 1700000000,
+          "Allowed Methods": [
+            {
+              "Contract Address": "0x1",
+              "Selector": "transfer"
+            },
+            {
+              "Contract Address": "0x2",
+              "Selector": "approve"
+            },
+            {
+              "Contract Address": "0x3",
+              "Selector": "mint"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Session": "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\")\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")",
+          "Allowed Method": "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Session": "0x1c596d7455b21f95e0226344b87710b9583baf63b793be8cd2530d2464bbab6",
+          "Allowed Method": "0x349e733d483ab6810e692f381677b7ea1e37a3d2972c55b3f91e01ea8ec4a35"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x105c439d7743b2c79adb1b2ceba6411af5434475383073236eccbd8c76cecc5",
+        "message_hash": "0x793a5185bea41369715ff94f6070d30aa3c3583c4bb32993db7ad36da71b679"
+      }
+    },
+    {
+      "name": "merkletree-5-leaves",
+      "description": "Two levels with promotion.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Session": [
+            {
+              "name": "Expires At",
+              "type": "timestamp"
+            },
+            {
+              "name": "Allowed Methods",
+              "type": "merkletree",
+              "contains": "Allowed Method"
+            }
+          ],
+          "Allowed Method": [
+            {
+              "name": "Contract Address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Selector",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "Session",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Expires At": 1700000000,
+          "Allowed Methods": [
+            {
+              "Contract Address": "0x1",
+              "Selector": "transfer"
+            },
+            {
+              "Contract Address": "0x2",
+              "Selector": "approve"
+            },
+            {
+              "Contract Address": "0x3",
+              "Selector": "mint"
+            },
+            {
+              "Contract Address": "0x4",
+              "Selector": "burn"
+            },
+            {
+              "Contract Address": "0x5",
+              "Selector": "swap"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Session": "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\")\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")",
+          "Allowed Method": "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"Selector\":\"selector\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Session": "0x1c596d7455b21f95e0226344b87710b9583baf63b793be8cd2530d2464bbab6",
+          "Allowed Method": "0x349e733d483ab6810e692f381677b7ea1e37a3d2972c55b3f91e01ea8ec4a35"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x6ae2dd199dea3bd482d27c53a61bc01580b44690b9722bfb60b9dc40704d9c1",
+        "message_hash": "0x5da7d0a676712a21abd789db993ac13151b1bb1728ca0259fadc4fecfe1620"
+      }
+    },
+    {
+      "name": "merkletree-of-enums",
+      "description": "Leaves may be enums.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Policy": [
+            {
+              "name": "Rules",
+              "type": "merkletree",
+              "contains": "Rule"
+            }
+          ],
+          "Rule": [
+            {
+              "name": "Allow",
+              "type": "(ContractAddress)"
+            },
+            {
+              "name": "Deny All",
+              "type": "()"
+            }
+          ]
+        },
+        "primaryType": "Policy",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Rules": [
+            {
+              "Allow": [
+                "0x1"
+              ]
+            },
+            {
+              "Deny All": []
+            },
+            {
+              "Allow": [
+                "0x2"
+              ]
+            }
+          ]
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Policy": "\"Policy\"(\"Rules\":\"merkletree\")\"Rule\"(\"Allow\"(\"ContractAddress\"),\"Deny All\"())",
+          "Rule": "\"Rule\"(\"Allow\"(\"ContractAddress\"),\"Deny All\"())"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Policy": "0x18f91151074545d7f7cc0d7acff8ce0697651c9554eaf641f5b30a48a69dfce",
+          "Rule": "0x213672d2bc88e5b4eb8f9caa8e0d3418ad8a98b3533342a94887735de176c32"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x38716e05c582b0d0ceb79d65288dc90c09bf3c3d2712ef9db6f3274a836b867",
+        "message_hash": "0x4c7dcc146808a04429dbd3697feacce4464abc31a9bb849fdb2bc280d907182"
+      }
+    },
+    {
+      "name": "domain-verifying-contract",
+      "description": "Optional verifyingContract in the domain.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            },
+            {
+              "name": "verifyingContract",
+              "type": "ContractAddress"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2",
+          "verifyingContract": "0x0777"
+        },
+        "message": {
+          "n": 1
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\",\"verifyingContract\":\"ContractAddress\")",
+          "Ping": "\"Ping\"(\"n\":\"u8\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x22a208060c1d6c5515c9576d39d2b7c812e54202f1e05ea6428500efb4b6a8b",
+          "Ping": "0x351274262ab1c14ee75490b3e5216a9ef59a8fec7b4cb7110e297dd4de697ac"
+        },
+        "domain_hash": "0x202fa290bb6d1e7cd41855e05127cf551c87af34f47bf032707d2515eaba09f",
+        "struct_hash": "0x558305362c387f41a3faf93b835f36a7066f6c0960fe69b1e1a8823ef19b13d",
+        "message_hash": "0x25de19ad50ba0b1f809ab3ccd758e135530775c1e271227a1ed01a5c7a4d64f"
+      }
+    },
+    {
+      "name": "domain-salt",
+      "description": "Optional salt in the domain.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            },
+            {
+              "name": "salt",
+              "type": "felt"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2",
+          "salt": "0x5a17"
+        },
+        "message": {
+          "n": 1
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\",\"salt\":\"felt\")",
+          "Ping": "\"Ping\"(\"n\":\"u8\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0xa6be7486d2812c36d3c878d0053106533675d70a104fe5600617305bcac793",
+          "Ping": "0x351274262ab1c14ee75490b3e5216a9ef59a8fec7b4cb7110e297dd4de697ac"
+        },
+        "domain_hash": "0x5314b052a38ef059392f189f8a622a1e7e4a25be4f04d9ebcaa7b184a65e6cc",
+        "struct_hash": "0x558305362c387f41a3faf93b835f36a7066f6c0960fe69b1e1a8823ef19b13d",
+        "message_hash": "0x5207c463618e39511e0431ceef7864d18656c899eaeea3160834e2df72f2bd3"
+      }
+    },
+    {
+      "name": "domain-verifying-contract-and-salt",
+      "description": "Both optional domain fields, in the required order.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            },
+            {
+              "name": "verifyingContract",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "salt",
+              "type": "felt"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2",
+          "verifyingContract": "0x0777",
+          "salt": "0x5a17"
+        },
+        "message": {
+          "n": 1
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\",\"verifyingContract\":\"ContractAddress\",\"salt\":\"felt\")",
+          "Ping": "\"Ping\"(\"n\":\"u8\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x3d8dc39daf4e8de4ab71497d1947ca1e97d04084a7889c13434359080e3797f",
+          "Ping": "0x351274262ab1c14ee75490b3e5216a9ef59a8fec7b4cb7110e297dd4de697ac"
+        },
+        "domain_hash": "0x435c7c2226acd73f5304c1a61511eb6a01c6446b058b2d70951b8d349eab89",
+        "struct_hash": "0x558305362c387f41a3faf93b835f36a7066f6c0960fe69b1e1a8823ef19b13d",
+        "message_hash": "0x49cb31da1cbaa7809fcb4ee06f758a4e354b4b9d709c5cfa60a67e61000c183"
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "name": "revision-as-number",
+      "reason": "revision must be the JSON string \"2\"",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": 2
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "revision-1-document",
+      "reason": "a revision 1 document is not a revision 2 document",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "1"
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "domain-extra-field",
+      "reason": "domain object has a field the domain type does not declare",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2",
+          "extra": 1
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "domain-chain_id-key",
+      "reason": "legacy chain_id key",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "revision": "2",
+          "chain_id": "SN_SEPOLIA"
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "domain-fields-reordered",
+      "reason": "domain type fields must be in the specified order",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "domain-optional-out-of-order",
+      "reason": "salt must come after verifyingContract",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            },
+            {
+              "name": "salt",
+              "type": "felt"
+            },
+            {
+              "name": "verifyingContract",
+              "type": "ContractAddress"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2",
+          "salt": "0x1",
+          "verifyingContract": "0x2"
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "primary-type-is-domain",
+      "reason": "primaryType cannot be StarknetDomain",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "StarknetDomain",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        }
+      }
+    },
+    {
+      "name": "unknown-type",
+      "reason": "field type is neither basic nor declared",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "uint256"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "dangling-type",
+      "reason": "declared type not reachable from primaryType",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ],
+          "Unused": [
+            {
+              "name": "x",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1
+        }
+      }
+    },
+    {
+      "name": "recursive-type",
+      "reason": "recursive type definitions are not allowed",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Node": [
+            {
+              "name": "children",
+              "type": "Node*"
+            }
+          ]
+        },
+        "primaryType": "Node",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "children": []
+        }
+      }
+    },
+    {
+      "name": "message-undeclared-field",
+      "reason": "message has a field the type does not declare",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1,
+          "extra": 2
+        }
+      }
+    },
+    {
+      "name": "message-missing-field",
+      "reason": "message lacks a declared field",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {}
+      }
+    },
+    {
+      "name": "u8-out-of-range",
+      "reason": "value exceeds the type range",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 256
+        }
+      }
+    },
+    {
+      "name": "u64-negative",
+      "reason": "unsigned type given a negative value",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "u64"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": -1
+        }
+      }
+    },
+    {
+      "name": "i8-out-of-range",
+      "reason": "signed value below the type range",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "i8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": -129
+        }
+      }
+    },
+    {
+      "name": "felt-at-prime",
+      "reason": "felt must be below the field prime",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "felt"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": "0x800000000000011000000000000000000000000000000000000000000000001"
+        }
+      }
+    },
+    {
+      "name": "address-above-bound",
+      "reason": "ContractAddress must be below 2^251",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "a",
+              "type": "ContractAddress"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a": "0x800000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    },
+    {
+      "name": "selector-hex",
+      "reason": "selector values must be entrypoint names, never hashes",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": "0x1"
+        }
+      }
+    },
+    {
+      "name": "selector-invalid-identifier",
+      "reason": "selector must be a Cairo identifier",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": "trans fer"
+        }
+      }
+    },
+    {
+      "name": "shortstring-too-long",
+      "reason": "shortstring longer than 31 bytes",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "shortstring"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": "abcdefghijklmnopqrstuvwxyz012345"
+        }
+      }
+    },
+    {
+      "name": "shortstring-non-ascii",
+      "reason": "shortstring must be printable ASCII",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "shortstring"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": "héllo"
+        }
+      }
+    },
+    {
+      "name": "shortstring-as-number",
+      "reason": "shortstring values must be JSON strings",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "shortstring"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": 2
+        }
+      }
+    },
+    {
+      "name": "bool-as-string",
+      "reason": "bool must be a JSON boolean",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "b",
+              "type": "bool"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "b": "true"
+        }
+      }
+    },
+    {
+      "name": "reserved-type-name",
+      "reason": "user types cannot use a basic type name",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "u256": [
+            {
+              "name": "low",
+              "type": "u128"
+            }
+          ],
+          "T": [
+            {
+              "name": "a",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a": {
+            "low": 1
+          }
+        }
+      }
+    },
+    {
+      "name": "tuple-field-type",
+      "reason": "tuples are not a SNIP-12 type; model them as a struct",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "(felt,u128)"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": [
+            1,
+            2
+          ]
+        }
+      }
+    },
+    {
+      "name": "duplicate-field-name",
+      "reason": "field names within a type must be unique",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "a",
+              "type": "u8"
+            },
+            {
+              "name": "a",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a": 1
+        }
+      }
+    },
+    {
+      "name": "name-with-quote",
+      "reason": "names cannot contain the double quote character",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "a\"b",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a\"b": 1
+        }
+      }
+    },
+    {
+      "name": "name-with-colon",
+      "reason": "names cannot contain the colon character",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "a:b",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a:b": 1
+        }
+      }
+    },
+    {
+      "name": "name-trailing-space",
+      "reason": "names cannot start or end with whitespace",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "a ",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a ": 1
+        }
+      }
+    },
+    {
+      "name": "type-name-with-star",
+      "reason": "type names cannot end with *",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T*": [
+            {
+              "name": "a",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T*",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a": 1
+        }
+      }
+    },
+    {
+      "name": "enum-two-keys",
+      "reason": "an enum value has exactly one variant key",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "No Fee": [],
+            "Split": [
+              1,
+              []
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "enum-unknown-variant",
+      "reason": "variant not declared",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "Free": []
+          }
+        }
+      }
+    },
+    {
+      "name": "enum-param-count",
+      "reason": "variant parameters must match the declaration",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "Split": [
+              1
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "enum-with-contains",
+      "reason": "revision 2 references enums by name; the \"enum\" pseudo-type is gone",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "enum",
+              "contains": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Payment",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Payer": "0x1",
+          "Fee": {
+            "No Fee": []
+          }
+        }
+      }
+    },
+    {
+      "name": "merkletree-missing-contains",
+      "reason": "merkletree fields must name their leaf type",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "m",
+              "type": "merkletree"
+            }
+          ],
+          "L": [
+            {
+              "name": "x",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "m": [
+            {
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "merkletree-empty",
+      "reason": "a merkletree must have at least one leaf",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Session": [
+            {
+              "name": "Expires At",
+              "type": "timestamp"
+            },
+            {
+              "name": "Allowed Methods",
+              "type": "merkletree",
+              "contains": "Allowed Method"
+            }
+          ],
+          "Allowed Method": [
+            {
+              "name": "Contract Address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Selector",
+              "type": "selector"
+            }
+          ]
+        },
+        "primaryType": "Session",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Expires At": 1,
+          "Allowed Methods": []
+        }
+      }
+    },
+    {
+      "name": "merkletree-basic-leaf",
+      "reason": "leaves must be user-defined structs or enums",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "m",
+              "type": "merkletree",
+              "contains": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "m": [
+            1,
+            2
+          ]
+        }
+      }
+    },
+    {
+      "name": "array-given-scalar",
+      "reason": "array-typed field given a scalar",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "a",
+              "type": "u8*"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "a": 1
+        }
+      }
+    },
+    {
+      "name": "struct-given-array",
+      "reason": "struct-typed field given an array",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "i",
+              "type": "Item"
+            }
+          ],
+          "Item": [
+            {
+              "name": "x",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "i": [
+            1
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/assets/snip-12/rev2/vectors.json
+++ b/assets/snip-12/rev2/vectors.json
@@ -1336,6 +1336,126 @@
       }
     },
     {
+      "name": "domain-descriptor-key-order",
+      "description": "Key order inside a field descriptor is not significant; this hashes identically to the same document written {name, type}.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "type": "shortstring",
+              "name": "name"
+            },
+            {
+              "type": "shortstring",
+              "name": "version"
+            },
+            {
+              "type": "shortstring",
+              "name": "chainId"
+            },
+            {
+              "type": "shortstring",
+              "name": "revision"
+            }
+          ],
+          "Ping": [
+            {
+              "name": "n",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "Ping",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Ping": "\"Ping\"(\"n\":\"u8\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Ping": "0x351274262ab1c14ee75490b3e5216a9ef59a8fec7b4cb7110e297dd4de697ac"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x558305362c387f41a3faf93b835f36a7066f6c0960fe69b1e1a8823ef19b13d",
+        "message_hash": "0x5ff8156e38eda100896a106eae827ac1a173853a86e8194827740f9523984f"
+      }
+    },
+    {
+      "name": "json-number-limits",
+      "description": "A JSON number may be used up to 2^53 - 1; anything larger must be a decimal or 0x string (here 2^53 in both string forms).",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Limits": [
+            {
+              "name": "Max Number",
+              "type": "u64"
+            },
+            {
+              "name": "Decimal String",
+              "type": "u64"
+            },
+            {
+              "name": "Hex String",
+              "type": "u64"
+            }
+          ]
+        },
+        "primaryType": "Limits",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "Max Number": 9007199254740991,
+          "Decimal String": "9007199254740992",
+          "Hex String": "0x20000000000000"
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Limits": "\"Limits\"(\"Max Number\":\"u64\",\"Decimal String\":\"u64\",\"Hex String\":\"u64\")"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Limits": "0x311b5f786c840c121a32259a4e13f288a42dfe5dca6d1bdd699a265380156d7"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x77e1c7a6b10ec003facef5ab90fd44aa281cdd3852e7be82143c449fcd7cc0d",
+        "message_hash": "0x3b72823f21dfa2a120aa089b08e0ad5ede9450be55359277b27ebc6a462c01f"
+      }
+    },
+    {
       "name": "domain-verifying-contract",
       "description": "Optional verifyingContract in the domain.",
       "typed_data": {
@@ -2336,6 +2456,217 @@
         },
         "message": {
           "s": "trans fer"
+        }
+      }
+    },
+    {
+      "name": "json-number-above-limit",
+      "reason": "a JSON number above 2^53 - 1 must be given as a string",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "u64"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 9007199254740992
+        }
+      }
+    },
+    {
+      "name": "json-number-fractional",
+      "reason": "a JSON number must be a whole number",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "u64"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1.5
+        }
+      }
+    },
+    {
+      "name": "string-unpaired-high-surrogate",
+      "reason": "string values must be well-formed Unicode",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "string"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": "a\ud800b"
+        }
+      }
+    },
+    {
+      "name": "string-unpaired-low-surrogate",
+      "reason": "string values must be well-formed Unicode",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "s",
+              "type": "string"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "s": "a\udc00b"
+        }
+      }
+    },
+    {
+      "name": "field-descriptor-unknown-key",
+      "reason": "a field descriptor may only carry name, type and (for merkletree) contains",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "u8",
+              "display": "hex"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1
         }
       }
     },

--- a/assets/snip-12/rev2/vectors.json
+++ b/assets/snip-12/rev2/vectors.json
@@ -1268,6 +1268,74 @@
       }
     },
     {
+      "name": "single-variant-enum",
+      "description": "A type whose only field type is parenthesised is a one-variant enum, not a tuple; nested in a struct it is valid.",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Wrapper": [
+            {
+              "name": "pair",
+              "type": "Pair"
+            }
+          ],
+          "Pair": [
+            {
+              "name": "Values",
+              "type": "(felt,u128)"
+            }
+          ]
+        },
+        "primaryType": "Wrapper",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "pair": {
+            "Values": [
+              1,
+              2
+            ]
+          }
+        }
+      },
+      "expected": {
+        "encode_type": {
+          "StarknetDomain": "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+          "Wrapper": "\"Wrapper\"(\"pair\":\"Pair\")\"Pair\"(\"Values\"(\"felt\",\"u128\"))",
+          "Pair": "\"Pair\"(\"Values\"(\"felt\",\"u128\"))"
+        },
+        "type_hash": {
+          "StarknetDomain": "0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210",
+          "Wrapper": "0x1c68b304ada3dd64b867f5dce2a84a222453d2cb5189248f7a270563e394451",
+          "Pair": "0x210ebf2e5dacc2755bc86f5ff49e2df463bc10c8f6b4a012170a4cf2da78029"
+        },
+        "domain_hash": "0x48e63e9c7cb93bcb202e9134b55cc3d17890eebf376dd23ef411e669f0dd608",
+        "struct_hash": "0x1a623aca460c349afe76d13e8e1a6da9465a3a8f0653fc4b32ef185ae89f30d",
+        "message_hash": "0x1aa4a70a56d8a040d3a226207cf136604e35fc9aeaf61cb194d44dac6998bdc"
+      }
+    },
+    {
       "name": "domain-verifying-contract",
       "description": "Optional verifyingContract in the domain.",
       "typed_data": {
@@ -2490,8 +2558,8 @@
       }
     },
     {
-      "name": "tuple-field-type",
-      "reason": "tuples are not a SNIP-12 type; model them as a struct",
+      "name": "tuple-as-primary-type",
+      "reason": "an all-parenthesised type is an enum, and primaryType must be a struct",
       "typed_data": {
         "types": {
           "StarknetDomain": [
@@ -2531,6 +2599,179 @@
             1,
             2
           ]
+        }
+      }
+    },
+    {
+      "name": "tuple-next-to-struct-field",
+      "reason": "a type mixes struct fields and enum variants",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "T": [
+            {
+              "name": "n",
+              "type": "(felt,u128)"
+            },
+            {
+              "name": "m",
+              "type": "u8"
+            }
+          ]
+        },
+        "primaryType": "T",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": [
+            1,
+            2
+          ],
+          "m": 1
+        }
+      }
+    },
+    {
+      "name": "enum-as-primary-type",
+      "reason": "primaryType must be a struct",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "Payment": [
+            {
+              "name": "Payer",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "Fee",
+              "type": "Fee Mode"
+            }
+          ],
+          "Fee Mode": [
+            {
+              "name": "No Fee",
+              "type": "()"
+            },
+            {
+              "name": "Pay Fee",
+              "type": "(Fee Transfer)"
+            },
+            {
+              "name": "Split",
+              "type": "(u128,u128*)"
+            }
+          ],
+          "Fee Transfer": [
+            {
+              "name": "Fee Amount",
+              "type": "TokenAmount"
+            },
+            {
+              "name": "Fee Receiver",
+              "type": "ContractAddress"
+            }
+          ],
+          "TokenAmount": [
+            {
+              "name": "token_address",
+              "type": "ContractAddress"
+            },
+            {
+              "name": "amount",
+              "type": "u256"
+            }
+          ]
+        },
+        "primaryType": "Fee Mode",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "No Fee": []
+        }
+      }
+    },
+    {
+      "name": "contains-on-non-merkletree",
+      "reason": "\"contains\" is only allowed on merkletree fields",
+      "typed_data": {
+        "types": {
+          "StarknetDomain": [
+            {
+              "name": "name",
+              "type": "shortstring"
+            },
+            {
+              "name": "version",
+              "type": "shortstring"
+            },
+            {
+              "name": "chainId",
+              "type": "shortstring"
+            },
+            {
+              "name": "revision",
+              "type": "shortstring"
+            }
+          ],
+          "P": [
+            {
+              "name": "n",
+              "type": "u8",
+              "contains": "NoSuchType"
+            }
+          ]
+        },
+        "primaryType": "P",
+        "domain": {
+          "name": "SNIP-12 Rev 2 Vectors",
+          "version": "1",
+          "chainId": "SN_SEPOLIA",
+          "revision": "2"
+        },
+        "message": {
+          "n": 1
         }
       }
     },


### PR DESCRIPTION
## Summary

Draft of **SNIP-12 revision 2**, opened for discussion. Revision 0 and revision 1 hashing is untouched; the PR adds a self-contained "Revision 2 (draft)" section, a reference encoder, and test vectors.

### What revision 2 changes

| Aspect | Revision 1 | Revision 2 |
| --- | --- | --- |
| `revision` value | integer `1` | shortstring `"2"` (`0x32`); unknown revisions MUST be rejected |
| Domain | 4 fields | + optional `verifyingContract`; `chainId` must match the connected chain |
| `u256` / presets | preset structs with type-hash prefix (text) vs flattened (OpenZeppelin) | `u256` is a basic type encoded as two felts; `TokenAmount` / `NftId` become ordinary structs |
| Enums | `"type": "enum", "contains"`; colon and type-hash ambiguities | referenced by name; `"E"("V"("u128"))`; value `hash_array(type_hash, index, params...)` |
| Integers | `u128`, `i128` | `u8`..`u128`, `i8`..`i128`, `bytes31`, `timestamp` = `u64` |
| `shortstring` / `selector` | numeric strings and hex selectors pass through as numbers | always ASCII bytes / always `starknet_keccak(identifier)` |
| Names | JSON escaping (three different implementations) | printable ASCII minus `" \ ( ) , : *`; escaping is quoting |
| Merkle tree, `string`, nested arrays, tuples | undefined | defined; there is no tuple type (an all-parenthesised type is an enum) |
| Validation | type-name rules | full MUST-reject list incl. undeclared / missing message fields |
| Test vectors | none | `assets/snip-12/rev2/vectors.json` |

### Why

The revision 1 text and the shipped implementations disagree in ways that break interoperability today (see the "Why a new revision" subsection for references): `u256` nesting vs flattening (starknet.js #1464, SNIPs #176), enum type strings and values (starknet.js #1286, #1278, #1341; Zellic audit of OpenZeppelin Cairo Contracts v4, finding 3.13), numeric short strings (#1039), selector passthrough (#1348), and undefined merkle tree / string / escaping rules. Revision 1 hashes are frozen in deployed account contracts via SNIP-9 v2, so these can only be fixed in a new revision.

Two facts from the ecosystem shaped the draft:
- Cartridge Controller's `execute_from_outside_v3` already hashes its domain with the **felt `2`** in the revision slot under revision-1 rules, so revision 2 must use the shortstring `"2"` (`0x32`) to avoid collisions. SNIP-29 already refers to a shortstring `"2"` revision.
- SNIP-9 v3 / SNIP-29 v3 drafts rely on exactly the constructs revision 1 leaves ambiguous (enums, `u256`, tuples). The migration notes recommend defining them on revision 2.

### What's in `assets/snip-12/rev2/`

- `encoder.mjs`: reference encoder implementing the section rule by rule (starknet.js is used only for Poseidon and `starknet_keccak`).
- `vectors.json`: 18 valid documents with `encode_type`, type hashes, domain hash, struct hash and message hash for account `0x1234`, plus 47 documents that MUST be rejected with the rule each violates.
- `vectors-src.mjs`, `package.json`, `README.md`: regenerate with `npm run generate`, check with `npm run verify`.

Sanity checks performed: type hashes reproduce the SNIP-9 v2 constants; struct hashing, message composition and `string` (ByteArray) encoding match starknet.js 10.7.2 revision 1 where the two revisions coincide.

### Changes since the first commit

- `8ba1336` (review by @franciszekjob): no tuple type, an all-parenthesised type is an enum; `primaryType` must be a struct; `contains` only on `merkletree` fields; wallet display rules split and extended (non-unique derived forms must be shown with the underlying value). +1 valid / +3 invalid vectors.
- `6825ab9` (external review): domain descriptors compared structurally, descriptor keys limited to `name`, `type`, `contains`; `string` must be well-formed Unicode (unpaired surrogates rejected); JSON numbers bounded to `+/-(2^53 - 1)`, larger values as strings. +2 valid / +5 invalid vectors.

- `b8f0568` (review by @ericnordelo): Notation subsection unifying `Enc` / `encode_type` / `type_hash` terminology; rationale for keeping `verifyingContract` optional (multi-contract workflows); open question 6 on Blake2s vs Poseidon with fee-schedule and measured gas figures.

- `741a8f3` (review by @PhilippeR26, @franciszekjob): merkle trees added to the revision-1 migration note (starknet.js differs on the node function and on odd nodes); open questions 1, 2, 4, 5, 6 closed as decided and recorded with reasoning; `salt` dropped from the domain (two valid `StarknetDomain` shapes remain); question 3 left open with positions.

No previously published expected hash changed in any commit. Revision 0 and 1 text is untouched throughout.

### Review status of the original open questions

Settled in review and recorded in the text with reasoning: 1 (`u256` flattened), 2 (no colon), 4 (prefix kept), 5 (`string` as ByteArray), 6 (Poseidon, no reopen clause). `salt` removed from the domain.

**Still open: 3, whether `verifyingContract` should be mandatory or optional.** Positions in the threads: mandatory and drop `salt` (@PhilippeR26); optional, with wallets required to display presence and warn on absence (@franciszekjob); optional because of multi-contract workflows (@ericnordelo). Input welcome.

Also touched: the domain-separator revision list now points to revision 2, the Implementation section links the encoder, and Security Considerations replaces "no impact" with actual considerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




